### PR TITLE
Ignore geth updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      # Update go-ethereum only via subnet-evm or avalanchego
+      - dependency-name: "go-ethereum"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Why this should be merged
We want to depend on geth implicitly via subnet-evm and avalanchego. We still use geth libraries, but we should only update them in tandem with subnet-evm and avalanchego.

## How this works
Adds `go-ethereum` to dependabot ignore
