### PR TITLE
Process missed blocks on startup

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -219,6 +219,9 @@ func (s *SourceSubnet) Validate() error {
 	if _, err := url.ParseRequestURI(s.GetNodeWSEndpoint()); err != nil {
 		return fmt.Errorf("invalid relayer subscribe URL in source subnet configuration: %v", err)
 	}
+	if _, err := url.ParseRequestURI(s.GetNodeRPCEndpoint()); err != nil {
+		return fmt.Errorf("invalid relayer RPC URL in source subnet configuration: %v", err)
+	}
 
 	// Validate the VM specific settings
 	switch ParseVM(s.VM) {

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ type SourceSubnet struct {
 	APINodeHost       string                           `mapstructure:"api-node-host" json:"api-node-host"`
 	APINodePort       uint32                           `mapstructure:"api-node-port" json:"api-node-port"`
 	EncryptConnection bool                             `mapstructure:"encrypt-connection" json:"encrypt-connection"`
+	RPCEndpoint       string                           `mapstructure:"rpc-endpoint" json:"rpc-endpoint"`
 	WSEndpoint        string                           `mapstructure:"ws-endpoint" json:"ws-endpoint"`
 	MessageContracts  map[string]MessageProtocolConfig `mapstructure:"message-contracts" json:"message-contracts"`
 }
@@ -283,6 +284,23 @@ func constructURL(protocol string, host string, port uint32, encrypt bool) strin
 // Otherwise, constructs the endpoint from the APINodeHost, APINodePort, and EncryptConnection fields,
 // following the /ext/bc/{chainID}/rpc format.
 func (s *DestinationSubnet) GetNodeRPCEndpoint() string {
+	if s.RPCEndpoint != "" {
+		return s.RPCEndpoint
+	}
+	baseUrl := constructURL("http", s.APINodeHost, s.APINodePort, s.EncryptConnection)
+	chainID := s.ChainID
+	subnetID, _ := ids.FromString(s.SubnetID) // already validated in Validate()
+	if subnetID == constants.PrimaryNetworkID {
+		chainID = cChainIdentifierString
+	}
+	return fmt.Sprintf("%s/ext/bc/%s/rpc", baseUrl, chainID)
+}
+
+// Constructs an RPC endpoint for the subnet.
+// If the RPCEndpoint field is set in the configuration, returns that directly.
+// Otherwise, constructs the endpoint from the APINodeHost, APINodePort, and EncryptConnection fields,
+// following the /ext/bc/{chainID}/rpc format.
+func (s *SourceSubnet) GetNodeRPCEndpoint() string {
 	if s.RPCEndpoint != "" {
 		return s.RPCEndpoint
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -299,7 +299,9 @@ func (s *DestinationSubnet) GetNodeRPCEndpoint() string {
 	if subnetID == constants.PrimaryNetworkID {
 		chainID = cChainIdentifierString
 	}
-	return fmt.Sprintf("%s/ext/bc/%s/rpc", baseUrl, chainID)
+	// Save this result for future use
+	s.RPCEndpoint = fmt.Sprintf("%s/ext/bc/%s/rpc", baseUrl, chainID)
+	return s.RPCEndpoint
 }
 
 // Constructs an RPC endpoint for the subnet.
@@ -316,7 +318,9 @@ func (s *SourceSubnet) GetNodeRPCEndpoint() string {
 	if subnetID == constants.PrimaryNetworkID {
 		chainID = cChainIdentifierString
 	}
-	return fmt.Sprintf("%s/ext/bc/%s/rpc", baseUrl, chainID)
+	// Save this result for future use
+	s.RPCEndpoint = fmt.Sprintf("%s/ext/bc/%s/rpc", baseUrl, chainID)
+	return s.RPCEndpoint
 }
 
 // Constructs a WS endpoint for the subnet.
@@ -333,7 +337,9 @@ func (s *SourceSubnet) GetNodeWSEndpoint() string {
 	if subnetID == constants.PrimaryNetworkID {
 		chainID = cChainIdentifierString
 	}
-	return fmt.Sprintf("%s/ext/bc/%s/ws", baseUrl, chainID)
+	// Save this result for future use
+	s.WSEndpoint = fmt.Sprintf("%s/ext/bc/%s/ws", baseUrl, chainID)
+	return s.WSEndpoint
 }
 
 // Get the private key and derive the wallet address from a relayer's configured private key for a given destination subnet.

--- a/config/config.go
+++ b/config/config.go
@@ -274,7 +274,13 @@ func (s *DestinationSubnet) Validate() error {
 	return nil
 }
 
-func constructURL(protocol string, host string, port uint32, encrypt bool) string {
+func constructURL(protocol string, host string, port uint32, encrypt bool, chainIDStr string, subnetIDStr string) string {
+	var protocolPathMap = map[string]string{
+		"http": "rpc",
+		"ws":   "ws",
+	}
+	path := protocolPathMap[protocol]
+
 	if encrypt {
 		protocol = protocol + "s"
 	}
@@ -282,7 +288,11 @@ func constructURL(protocol string, host string, port uint32, encrypt bool) strin
 	if port != 0 {
 		portStr = fmt.Sprintf(":%d", port)
 	}
-	return fmt.Sprintf("%s://%s%s", protocol, host, portStr)
+	subnetID, _ := ids.FromString(subnetIDStr) // already validated in Validate()
+	if subnetID == constants.PrimaryNetworkID {
+		chainIDStr = cChainIdentifierString
+	}
+	return fmt.Sprintf("%s://%s%s/ext/bc/%s/%s", protocol, host, portStr, chainIDStr, path)
 }
 
 // Constructs an RPC endpoint for the subnet.
@@ -293,14 +303,16 @@ func (s *DestinationSubnet) GetNodeRPCEndpoint() string {
 	if s.RPCEndpoint != "" {
 		return s.RPCEndpoint
 	}
-	baseUrl := constructURL("http", s.APINodeHost, s.APINodePort, s.EncryptConnection)
-	chainID := s.ChainID
-	subnetID, _ := ids.FromString(s.SubnetID) // already validated in Validate()
-	if subnetID == constants.PrimaryNetworkID {
-		chainID = cChainIdentifierString
-	}
+
 	// Save this result for future use
-	s.RPCEndpoint = fmt.Sprintf("%s/ext/bc/%s/rpc", baseUrl, chainID)
+	s.RPCEndpoint = constructURL(
+		"http",
+		s.APINodeHost,
+		s.APINodePort,
+		s.EncryptConnection,
+		s.ChainID,
+		s.SubnetID,
+	)
 	return s.RPCEndpoint
 }
 
@@ -312,14 +324,16 @@ func (s *SourceSubnet) GetNodeRPCEndpoint() string {
 	if s.RPCEndpoint != "" {
 		return s.RPCEndpoint
 	}
-	baseUrl := constructURL("http", s.APINodeHost, s.APINodePort, s.EncryptConnection)
-	chainID := s.ChainID
-	subnetID, _ := ids.FromString(s.SubnetID) // already validated in Validate()
-	if subnetID == constants.PrimaryNetworkID {
-		chainID = cChainIdentifierString
-	}
+
 	// Save this result for future use
-	s.RPCEndpoint = fmt.Sprintf("%s/ext/bc/%s/rpc", baseUrl, chainID)
+	s.RPCEndpoint = constructURL(
+		"http",
+		s.APINodeHost,
+		s.APINodePort,
+		s.EncryptConnection,
+		s.ChainID,
+		s.SubnetID,
+	)
 	return s.RPCEndpoint
 }
 
@@ -331,14 +345,16 @@ func (s *SourceSubnet) GetNodeWSEndpoint() string {
 	if s.WSEndpoint != "" {
 		return s.WSEndpoint
 	}
-	baseUrl := constructURL("ws", s.APINodeHost, s.APINodePort, s.EncryptConnection)
-	chainID := s.ChainID
-	subnetID, _ := ids.FromString(s.SubnetID) // already validated in Validate()
-	if subnetID == constants.PrimaryNetworkID {
-		chainID = cChainIdentifierString
-	}
+
 	// Save this result for future use
-	s.WSEndpoint = fmt.Sprintf("%s/ext/bc/%s/ws", baseUrl, chainID)
+	s.WSEndpoint = constructURL(
+		"ws",
+		s.APINodeHost,
+		s.APINodePort,
+		s.EncryptConnection,
+		s.ChainID,
+		s.SubnetID,
+	)
 	return s.WSEndpoint
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	NetworkID          uint32              `mapstructure:"network-id" json:"network-id"`
 	PChainAPIURL       string              `mapstructure:"p-chain-api-url" json:"p-chain-api-url"`
 	EncryptConnection  bool                `mapstructure:"encrypt-connection" json:"encrypt-connection"`
+	StorageLocation    string              `mapstructure:"storage-location" json:"storage-location"`
 	SourceSubnets      []SourceSubnet      `mapstructure:"source-subnets" json:"source-subnets"`
 	DestinationSubnets []DestinationSubnet `mapstructure:"destination-subnets" json:"destination-subnets"`
 }
@@ -72,6 +73,7 @@ func SetDefaultConfigValues(v *viper.Viper) {
 	v.SetDefault(NetworkIDKey, constants.MainnetID)
 	v.SetDefault(PChainAPIURLKey, "https://api.avax.network")
 	v.SetDefault(EncryptConnectionKey, true)
+	v.SetDefault(StorageLocationKey, "./awm-relayer-storage")
 }
 
 // BuildConfig constructs the relayer config using Viper.

--- a/config/config.go
+++ b/config/config.go
@@ -73,7 +73,7 @@ func SetDefaultConfigValues(v *viper.Viper) {
 	v.SetDefault(NetworkIDKey, constants.MainnetID)
 	v.SetDefault(PChainAPIURLKey, "https://api.avax.network")
 	v.SetDefault(EncryptConnectionKey, true)
-	v.SetDefault(StorageLocationKey, "./awm-relayer-storage")
+	v.SetDefault(StorageLocationKey, "./.awm-relayer-storage")
 }
 
 // BuildConfig constructs the relayer config using Viper.
@@ -102,6 +102,7 @@ func BuildConfig(v *viper.Viper) (Config, bool, error) {
 	cfg.NetworkID = v.GetUint32(NetworkIDKey)
 	cfg.PChainAPIURL = v.GetString(PChainAPIURLKey)
 	cfg.EncryptConnection = v.GetBool(EncryptConnectionKey)
+	cfg.StorageLocation = v.GetString(StorageLocationKey)
 	if err := v.UnmarshalKey(DestinationSubnetsKey, &cfg.DestinationSubnets); err != nil {
 		return Config{}, false, fmt.Errorf("failed to unmarshal destination subnets: %v", err)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -124,10 +124,11 @@ func TestGetDestinationRPCEndpoint(t *testing.T) {
 	}
 }
 
-func TestGetSourceSubnetWSEndpoint(t *testing.T) {
+func TestGetSourceSubnetEndpoints(t *testing.T) {
 	testCases := []struct {
-		s              SourceSubnet
-		expectedResult string
+		s                 SourceSubnet
+		expectedWsResult  string
+		expectedRpcResult string
 	}{
 		{
 			s: SourceSubnet{
@@ -137,7 +138,8 @@ func TestGetSourceSubnetWSEndpoint(t *testing.T) {
 				ChainID:           testChainID,
 				SubnetID:          testSubnetID,
 			},
-			expectedResult: fmt.Sprintf("ws://127.0.0.1:9650/ext/bc/%s/ws", testChainID),
+			expectedWsResult:  fmt.Sprintf("ws://127.0.0.1:9650/ext/bc/%s/ws", testChainID),
+			expectedRpcResult: fmt.Sprintf("http://127.0.0.1:9650/ext/bc/%s/rpc", testChainID),
 		},
 		{
 			s: SourceSubnet{
@@ -147,7 +149,8 @@ func TestGetSourceSubnetWSEndpoint(t *testing.T) {
 				ChainID:           testChainID,
 				SubnetID:          testSubnetID,
 			},
-			expectedResult: fmt.Sprintf("wss://127.0.0.1:9650/ext/bc/%s/ws", testChainID),
+			expectedWsResult:  fmt.Sprintf("wss://127.0.0.1:9650/ext/bc/%s/ws", testChainID),
+			expectedRpcResult: fmt.Sprintf("https://127.0.0.1:9650/ext/bc/%s/rpc", testChainID),
 		},
 		{
 			s: SourceSubnet{
@@ -157,7 +160,8 @@ func TestGetSourceSubnetWSEndpoint(t *testing.T) {
 				ChainID:           testChainID,
 				SubnetID:          testSubnetID,
 			},
-			expectedResult: fmt.Sprintf("ws://api.avax.network/ext/bc/%s/ws", testChainID),
+			expectedWsResult:  fmt.Sprintf("ws://api.avax.network/ext/bc/%s/ws", testChainID),
+			expectedRpcResult: fmt.Sprintf("http://api.avax.network/ext/bc/%s/rpc", testChainID),
 		},
 		{
 			s: SourceSubnet{
@@ -167,7 +171,8 @@ func TestGetSourceSubnetWSEndpoint(t *testing.T) {
 				ChainID:           testChainID,
 				SubnetID:          primarySubnetID,
 			},
-			expectedResult: "ws://127.0.0.1:9650/ext/bc/C/ws",
+			expectedWsResult:  "ws://127.0.0.1:9650/ext/bc/C/ws",
+			expectedRpcResult: "http://127.0.0.1:9650/ext/bc/C/rpc",
 		},
 		{
 			s: SourceSubnet{
@@ -176,15 +181,17 @@ func TestGetSourceSubnetWSEndpoint(t *testing.T) {
 				APINodePort:       9650,
 				ChainID:           testChainID,
 				SubnetID:          testSubnetID,
-				WSEndpoint:        "wss://subnets.avax.network/mysubnet/ws", // overrides all other settings used to construct the endpoint
+				WSEndpoint:        "wss://subnets.avax.network/mysubnet/ws",    // overrides all other settings used to construct the endpoint
+				RPCEndpoint:       "https://subnets.avax.network/mysubnet/rpc", // overrides all other settings used to construct the endpoint
 			},
-			expectedResult: "wss://subnets.avax.network/mysubnet/ws",
+			expectedWsResult:  "wss://subnets.avax.network/mysubnet/ws",
+			expectedRpcResult: "https://subnets.avax.network/mysubnet/rpc",
 		},
 	}
 
 	for i, testCase := range testCases {
-		res := testCase.s.GetNodeWSEndpoint()
-		assert.Equal(t, testCase.expectedResult, res, fmt.Sprintf("test case %d failed", i))
+		assert.Equal(t, testCase.expectedWsResult, testCase.s.GetNodeWSEndpoint(), fmt.Sprintf("test case %d failed", i))
+		assert.Equal(t, testCase.expectedRpcResult, testCase.s.GetNodeRPCEndpoint(), fmt.Sprintf("test case %d failed", i))
 	}
 }
 

--- a/config/keys.go
+++ b/config/keys.go
@@ -13,4 +13,5 @@ const (
 	DestinationSubnetsKey = "destination-subnets"
 	EncryptConnectionKey  = "encrypt-connection"
 	AccountPrivateKeyKey  = "account-private-key"
+	StorageLocationKey    = "storage-location"
 )

--- a/database/database.go
+++ b/database/database.go
@@ -3,7 +3,7 @@ package database
 import "github.com/ava-labs/avalanchego/ids"
 
 const (
-	LatestBlockHeightKey = "latestBlockHeight"
+	LatestProcessedBlockKey = "latestProcessedBlock"
 )
 
 // RelayerDatabase is a key-value store for relayer state, with each chainID maintaining its own state

--- a/database/database.go
+++ b/database/database.go
@@ -13,8 +13,9 @@ const (
 )
 
 var (
-	ErrKeyNotFound   = errors.New("key not found")
-	ErrChainNotFound = errors.New("no database for chain")
+	ErrKeyNotFound              = errors.New("key not found")
+	ErrChainNotFound            = errors.New("no database for chain")
+	ErrDatabaseMisconfiguration = errors.New("database misconfiguration")
 )
 
 // RelayerDatabase is a key-value store for relayer state, with each chainID maintaining its own state

--- a/database/database.go
+++ b/database/database.go
@@ -3,10 +3,18 @@
 
 package database
 
-import "github.com/ava-labs/avalanchego/ids"
+import (
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/pkg/errors"
+)
 
 const (
 	LatestSeenBlockKey = "latestSeenBlock"
+)
+
+var (
+	ErrKeyNotFound   = errors.New("key not found")
+	ErrChainNotFound = errors.New("no database for chain")
 )
 
 // RelayerDatabase is a key-value store for relayer state, with each chainID maintaining its own state

--- a/database/database.go
+++ b/database/database.go
@@ -2,6 +2,10 @@ package database
 
 import "github.com/ava-labs/avalanchego/ids"
 
+const (
+	LatestBlockHeightKey = "latestBlockHeight"
+)
+
 type RelayerDatabase interface {
 	Get(chainID ids.ID, key []byte) ([]byte, error)
 	Put(chainID ids.ID, key []byte, value []byte) error

--- a/database/database.go
+++ b/database/database.go
@@ -1,0 +1,8 @@
+package database
+
+import "github.com/ava-labs/avalanchego/ids"
+
+type RelayerDatabase interface {
+	Get(chainID ids.ID, key []byte) ([]byte, error)
+	Put(chainID ids.ID, key []byte, value []byte) error
+}

--- a/database/database.go
+++ b/database/database.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package database
 
 import "github.com/ava-labs/avalanchego/ids"

--- a/database/database.go
+++ b/database/database.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	LatestSeenBlockKey = "latestSeenBlock"
+	LatestProcessedBlockKey = "latestProcessedBlock"
 )
 
 var (

--- a/database/database.go
+++ b/database/database.go
@@ -6,6 +6,7 @@ const (
 	LatestBlockHeightKey = "latestBlockHeight"
 )
 
+// RelayerDatabase is a key-value store for relayer state, with each chainID maintaining its own state
 type RelayerDatabase interface {
 	Get(chainID ids.ID, key []byte) ([]byte, error)
 	Put(chainID ids.ID, key []byte, value []byte) error

--- a/database/database.go
+++ b/database/database.go
@@ -3,7 +3,7 @@ package database
 import "github.com/ava-labs/avalanchego/ids"
 
 const (
-	LatestProcessedBlockKey = "latestProcessedBlock"
+	LatestSeenBlockKey = "latestSeenBlock"
 )
 
 // RelayerDatabase is a key-value store for relayer state, with each chainID maintaining its own state

--- a/database/json_file_storage.go
+++ b/database/json_file_storage.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var _ RelayerDatabase = &JsonFileStorage{}
+var _ RelayerDatabase = &JSONFileStorage{}
 
 var (
 	fileDoesNotExistErr = errors.New("JSON database file does not exist")
@@ -20,21 +20,21 @@ var (
 
 type chainState map[string]string
 
-// JsonFileStorage implements RelayerDatabase
-type JsonFileStorage struct {
+// JSONFileStorage implements RelayerDatabase
+type JSONFileStorage struct {
 	// the directory where the json files are stored
 	dir string
 
 	// Each network has its own mutex
-	// The chainIDs used to index the JsonFileStorage are created at initialization
+	// The chainIDs used to index the JSONFileStorage are created at initialization
 	// and are not modified afterwards, so we don't need to lock the map itself.
 	mutexes map[ids.ID]*sync.RWMutex
 	logger  logging.Logger
 }
 
-// NewJSONFileStorage creates a new JsonFileStorage instance
-func NewJSONFileStorage(logger logging.Logger, dir string, networks []ids.ID) (*JsonFileStorage, error) {
-	storage := &JsonFileStorage{
+// NewJSONFileStorage creates a new JSONFileStorage instance
+func NewJSONFileStorage(logger logging.Logger, dir string, networks []ids.ID) (*JSONFileStorage, error) {
+	storage := &JSONFileStorage{
 		dir:     filepath.Clean(dir),
 		mutexes: make(map[ids.ID]*sync.RWMutex),
 		logger:  logger,
@@ -64,7 +64,7 @@ func NewJSONFileStorage(logger logging.Logger, dir string, networks []ids.ID) (*
 }
 
 // Get the latest chain state from the json database, and retrieve the value from the key
-func (s *JsonFileStorage) Get(chainID ids.ID, key []byte) ([]byte, error) {
+func (s *JSONFileStorage) Get(chainID ids.ID, key []byte) ([]byte, error) {
 	currentState := make(chainState)
 	fileExists, err := s.read(chainID, &currentState)
 	if err != nil {
@@ -82,7 +82,7 @@ func (s *JsonFileStorage) Get(chainID ids.ID, key []byte) ([]byte, error) {
 }
 
 // Put the value into the json database. Read the current chain state and overwrite the key, if it exists
-func (s *JsonFileStorage) Put(chainID ids.ID, key []byte, value []byte) error {
+func (s *JSONFileStorage) Put(chainID ids.ID, key []byte, value []byte) error {
 	currentState := make(chainState)
 	_, err := s.read(chainID, &currentState)
 	if err != nil {
@@ -99,7 +99,7 @@ func (s *JsonFileStorage) Put(chainID ids.ID, key []byte, value []byte) error {
 }
 
 // write value into the file
-func (s *JsonFileStorage) write(network ids.ID, v interface{}) error {
+func (s *JSONFileStorage) write(network ids.ID, v interface{}) error {
 	mutex, ok := s.mutexes[network]
 	if !ok {
 		return errors.New("network does not exist")
@@ -135,7 +135,7 @@ func (s *JsonFileStorage) write(network ids.ID, v interface{}) error {
 // Read from disk and unmarshal into v
 // Returns a bool indicating whether the file exists, and an error.
 // If an error is returned, the bool should be ignored.
-func (s *JsonFileStorage) read(network ids.ID, v interface{}) (bool, error) {
+func (s *JSONFileStorage) read(network ids.ID, v interface{}) (bool, error) {
 	mutex, ok := s.mutexes[network]
 	if !ok {
 		return false, errors.New("network does not exist")

--- a/database/json_file_storage.go
+++ b/database/json_file_storage.go
@@ -46,8 +46,8 @@ func NewJSONFileStorage(logger logging.Logger, dir string, networks []ids.ID) (*
 
 	_, err := os.Stat(dir)
 	if err == nil {
-		// dir already exist
-		// return the existing storage
+		// Directory already exists.
+		// Return the existing storage.
 		return storage, nil
 	}
 
@@ -64,7 +64,7 @@ func NewJSONFileStorage(logger logging.Logger, dir string, networks []ids.ID) (*
 	return storage, nil
 }
 
-// Get the latest chain state from the json database, and retrieve the value from the key
+// Get the latest chain state from the JSON database, and retrieve the value from the key
 func (s *JSONFileStorage) Get(chainID ids.ID, key []byte) ([]byte, error) {
 	mutex, ok := s.mutexes[chainID]
 	if !ok {
@@ -98,7 +98,7 @@ func (s *JSONFileStorage) Get(chainID ids.ID, key []byte) ([]byte, error) {
 	return []byte(val), nil
 }
 
-// Put the value into the json database. Read the current chain state and overwrite the key, if it exists
+// Put the value into the JSON database. Read the current chain state and overwrite the key, if it exists
 func (s *JSONFileStorage) Put(chainID ids.ID, key []byte, value []byte) error {
 	mutex, ok := s.mutexes[chainID]
 	if !ok {
@@ -137,15 +137,15 @@ func (s *JSONFileStorage) write(network ids.ID, v interface{}) error {
 		return err
 	}
 
-	// write marshaled data to the temp file
-	// if write failed, the original file is not affected
-	// 0644 Only the owner can read and write.
+	// Write marshaled data to the temp file.
+	// If  the write fails, the original file is not affected.
+	// Set file permissiones to 0644 so only the owner can read and write.
 	// Everyone else can only read. No one can execute the file.
 	if err := os.WriteFile(tmpPath, b, 0644); err != nil {
 		return errors.Wrap(err, "failed to write file")
 	}
 
-	// move final file into place
+	// Move final file into place
 	if err := os.Rename(tmpPath, fnlPath); err != nil {
 		return errors.Wrap(err, "failed to rename file")
 	}
@@ -176,7 +176,7 @@ func (s *JSONFileStorage) read(network ids.ID, v interface{}) (bool, error) {
 		return false, errors.Wrap(err, "failed to read file")
 	}
 
-	// unmarshal data
+	// Unmarshal data
 	if err = json.Unmarshal(b, &v); err != nil {
 		return false, errors.Wrap(err, "failed to unmarshal json file")
 	}

--- a/database/json_file_storage.go
+++ b/database/json_file_storage.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package database
 
 import (

--- a/database/json_file_storage.go
+++ b/database/json_file_storage.go
@@ -43,6 +43,7 @@ func NewJSONFileStorage(logger logging.Logger, dir string, networks []ids.ID) (*
 	}
 
 	for _, network := range networks {
+		storage.currentState[network] = make(chainState)
 		storage.mutexes[network] = &sync.RWMutex{}
 	}
 

--- a/database/json_file_storage.go
+++ b/database/json_file_storage.go
@@ -14,6 +14,10 @@ import (
 
 var _ RelayerDatabase = &JsonFileStorage{}
 
+var (
+	fileDoesNotExistErr = errors.New("JSON database file does not exist")
+)
+
 type chainState map[string]string
 
 // JsonFileStorage implements RelayerDatabase
@@ -21,16 +25,14 @@ type JsonFileStorage struct {
 	// the directory where the json files are stored
 	dir string
 
-	// one mutex per network
-	// we predefined the network when creating the storage
-	// also we don't allow adding new network after the storage is created
-	// so we don't need to lock the map
+	// Each network has its own mutex
+	// The chainIDs used to index the JsonFileStorage are created at initialization
+	// and are not modified afterwards, so we don't need to lock the map itself.
 	mutexes map[ids.ID]*sync.RWMutex
 	logger  logging.Logger
 }
 
 // NewJSONFileStorage creates a new JsonFileStorage instance
-// with predefined networks. e.g "ethereum", "avalanche"
 func NewJSONFileStorage(logger logging.Logger, dir string, networks []ids.ID) (*JsonFileStorage, error) {
 	storage := &JsonFileStorage{
 		dir:     filepath.Clean(dir),
@@ -64,9 +66,12 @@ func NewJSONFileStorage(logger logging.Logger, dir string, networks []ids.ID) (*
 // Get the latest chain state from the json database, and retrieve the value from the key
 func (s *JsonFileStorage) Get(chainID ids.ID, key []byte) ([]byte, error) {
 	var currentState chainState
-	err := s.read(chainID, &currentState)
+	fileExists, err := s.read(chainID, &currentState)
 	if err != nil {
 		return nil, err
+	}
+	if !fileExists {
+		return nil, fileDoesNotExistErr
 	}
 
 	return []byte(currentState[string(key)]), nil
@@ -76,8 +81,17 @@ func (s *JsonFileStorage) Get(chainID ids.ID, key []byte) ([]byte, error) {
 func (s *JsonFileStorage) Put(chainID ids.ID, key []byte, value []byte) error {
 	currentState := make(chainState)
 	var currentStateData []byte
-	err := s.read(chainID, &currentStateData)
-	if err == nil {
+	fileExists, err := s.read(chainID, &currentStateData)
+	if err != nil {
+		s.logger.Error(
+			"failed to read file",
+			zap.Error(err),
+		)
+		return err
+	}
+	// If the file exists, unmarshal the data into currentState
+	// Otherwise, we write the value to the empty currentState, and overwrite the file
+	if fileExists {
 		err = json.Unmarshal(currentStateData, &currentState)
 		if err != nil {
 			return err
@@ -124,30 +138,40 @@ func (s *JsonFileStorage) write(network ids.ID, v interface{}) error {
 }
 
 // Read from disk and unmarshal into v
-func (s *JsonFileStorage) read(network ids.ID, v interface{}) error {
+// Returns a bool indicating whether the file exists, and an error.
+// If an error is returned, the bool should be ignored.
+func (s *JsonFileStorage) read(network ids.ID, v interface{}) (bool, error) {
 	mutex, ok := s.mutexes[network]
 	if !ok {
-		return errors.New("network does not exist")
+		return false, errors.New("network does not exist")
 	}
 
 	mutex.RLock()
 	defer mutex.RUnlock()
 
 	path := filepath.Join(s.dir, network.String()+".json")
-	_, err := os.Stat(path)
-	if err != nil {
-		return err
+
+	// If the file does not exist, return false, but do not return an error as this
+	// is an expected case
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		s.logger.Debug(
+			"file does not exist",
+			zap.String("path", path),
+			zap.Error(err),
+		)
+		return false, nil
 	}
 
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return errors.Wrap(err, "failed to read file")
+		return false, errors.Wrap(err, "failed to read file")
 	}
 
 	// unmarshal data
 	if err = json.Unmarshal(b, &v); err != nil {
-		return errors.Wrap(err, "failed to unmarshal json file")
+		return false, errors.Wrap(err, "failed to unmarshal json file")
 	}
 
-	return nil
+	// Return true to indicate that the file exists and we read from it successfully
+	return true, nil
 }

--- a/database/json_file_storage.go
+++ b/database/json_file_storage.go
@@ -99,6 +99,7 @@ func (s *JSONFileStorage) Get(chainID ids.ID, key []byte) ([]byte, error) {
 }
 
 // Put the value into the JSON database. Read the current chain state and overwrite the key, if it exists
+// If the file corresponding to {chainID} does not exist, then it will be created
 func (s *JSONFileStorage) Put(chainID ids.ID, key []byte, value []byte) error {
 	mutex, ok := s.mutexes[chainID]
 	if !ok {
@@ -128,8 +129,8 @@ func (s *JSONFileStorage) Put(chainID ids.ID, key []byte, value []byte) error {
 }
 
 // Write the value to the file. The caller is responsible for ensuring proper synchronization
-func (s *JSONFileStorage) write(network ids.ID, v interface{}) error {
-	fnlPath := filepath.Join(s.dir, network.String()+".json")
+func (s *JSONFileStorage) write(chainID ids.ID, v interface{}) error {
+	fnlPath := filepath.Join(s.dir, chainID.String()+".json")
 	tmpPath := fnlPath + ".tmp"
 
 	b, err := json.MarshalIndent(v, "", "\t")
@@ -157,8 +158,8 @@ func (s *JSONFileStorage) write(network ids.ID, v interface{}) error {
 // Returns a bool indicating whether the file exists, and an error.
 // If an error is returned, the bool should be ignored.
 // The caller is responsible for ensuring proper synchronization
-func (s *JSONFileStorage) read(network ids.ID, v interface{}) (bool, error) {
-	path := filepath.Join(s.dir, network.String()+".json")
+func (s *JSONFileStorage) read(chainID ids.ID, v interface{}) (bool, error) {
+	path := filepath.Join(s.dir, chainID.String()+".json")
 
 	// If the file does not exist, return false, but do not return an error as this
 	// is an expected case

--- a/database/json_file_storage.go
+++ b/database/json_file_storage.go
@@ -1,0 +1,153 @@
+package database
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+var _ RelayerDatabase = &JsonFileStorage{}
+
+type chainState map[string]string
+
+// JsonFileStorage implements RelayerDatabase
+type JsonFileStorage struct {
+	// the directory where the json files are stored
+	dir string
+
+	// one mutex per network
+	// we predefined the network when creating the storage
+	// also we don't allow adding new network after the storage is created
+	// so we don't need to lock the map
+	mutexes map[string]*sync.RWMutex
+	logger  logging.Logger
+}
+
+// NewJSONFileStorage creates a new JsonFileStorage instance
+// with predefined networks. e.g "ethereum", "avalanche"
+func NewJSONFileStorage(logger logging.Logger, dir string, networks []string) (*JsonFileStorage, error) {
+	storage := &JsonFileStorage{
+		dir:     filepath.Clean(dir),
+		mutexes: make(map[string]*sync.RWMutex),
+		logger:  logger,
+	}
+
+	for _, network := range networks {
+		storage.mutexes[network] = &sync.RWMutex{}
+	}
+
+	_, err := os.Stat(dir)
+	if err == nil {
+		// dir already exist
+		// return the existing storage
+		return storage, nil
+	}
+
+	// 0755: The owner can read, write, execute.
+	// Everyone else can read and execute but not modify the file.
+	err = os.MkdirAll(dir, 0755)
+	if err != nil {
+		storage.logger.Error("failed to create dir",
+			zap.Error(err))
+		return nil, err
+	}
+
+	return storage, nil
+}
+
+// Get the latest chain state from the json database, and retrieve the value from the key
+func (s *JsonFileStorage) Get(chainID ids.ID, key []byte) ([]byte, error) {
+	var currentState chainState
+	err := s.read(chainID.String(), &currentState)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(currentState[string(key)]), nil
+}
+
+// Put the value into the json database. Read the current chain state and overwrite the key, if it exists
+func (s *JsonFileStorage) Put(chainID ids.ID, key []byte, value []byte) error {
+	currentState := make(chainState)
+	var currentStateData []byte
+	err := s.read(chainID.String(), &currentStateData)
+	if err == nil {
+		err = json.Unmarshal(currentStateData, &currentState)
+		if err != nil {
+			return err
+		}
+	}
+
+	currentState[string(key)] = string(value)
+
+	return s.write(chainID.String(), currentState)
+}
+
+// write value into the file
+func (s *JsonFileStorage) write(network string, v interface{}) error {
+	mutex, ok := s.mutexes[network]
+	if !ok {
+		return errors.New("network does not exist")
+	}
+
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	fnlPath := filepath.Join(s.dir, network+".json")
+	tmpPath := fnlPath + ".tmp"
+
+	b, err := json.MarshalIndent(v, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	// write marshaled data to the temp file
+	// if write failed, the original file is not affected
+	// 0644 Only the owner can read and write.
+	// Everyone else can only read. No one can execute the file.
+	if err := os.WriteFile(tmpPath, b, 0644); err != nil {
+		return errors.Wrap(err, "failed to write file")
+	}
+
+	// move final file into place
+	if err := os.Rename(tmpPath, fnlPath); err != nil {
+		return errors.Wrap(err, "failed to rename file")
+	}
+
+	return nil
+}
+
+// Read from disk and unmarshal into v
+func (s *JsonFileStorage) read(network string, v interface{}) error {
+	mutex, ok := s.mutexes[network]
+	if !ok {
+		return errors.New("network does not exist")
+	}
+
+	mutex.RLock()
+	defer mutex.RUnlock()
+
+	path := filepath.Join(s.dir, network+".json")
+	_, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return errors.Wrap(err, "failed to read file")
+	}
+
+	// unmarshal data
+	if err = json.Unmarshal(b, &v); err != nil {
+		return errors.Wrap(err, "failed to unmarshal json file")
+	}
+
+	return nil
+}

--- a/database/json_file_storage.go
+++ b/database/json_file_storage.go
@@ -67,7 +67,7 @@ func NewJSONFileStorage(logger logging.Logger, dir string, networks []ids.ID) (*
 func (s *JSONFileStorage) Get(chainID ids.ID, key []byte) ([]byte, error) {
 	mutex, ok := s.mutexes[chainID]
 	if !ok {
-		return nil, errors.New("network does not exist")
+		return nil, errors.New("database not configured for chain")
 	}
 
 	mutex.RLock()
@@ -83,14 +83,14 @@ func (s *JSONFileStorage) Get(chainID ids.ID, key []byte) ([]byte, error) {
 		return nil, err
 	}
 	if !fileExists {
-		return nil, errors.Errorf("file does not exist. chainID: %s", chainID)
+		return nil, ErrChainNotFound
 	}
 
 	if val, ok := currentState[string(key)]; ok {
 		return []byte(val), nil
 	}
 
-	return nil, errors.Errorf("key does not exist. chainID: %s key: %s", chainID, key)
+	return nil, ErrKeyNotFound
 }
 
 // Put the value into the json database. Read the current chain state and overwrite the key, if it exists

--- a/database/json_file_storage_test.go
+++ b/database/json_file_storage_test.go
@@ -27,9 +27,10 @@ func TestConcurrentWriteReadSingleChain(t *testing.T) {
 	wg := sync.WaitGroup{}
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
+		idx := i
 		go func() {
 			defer wg.Done()
-			testWrite(jsonStorage, networks[0], uint64(i))
+			testWrite(jsonStorage, networks[0], uint64(idx))
 		}()
 	}
 	wg.Wait()
@@ -47,7 +48,6 @@ func TestConcurrentWriteReadSingleChain(t *testing.T) {
 		t.Fatalf("failed to convert latest block to big.Int. err: %v", err)
 	}
 	assert.Equal(t, finalTargetValue, latestProcessedBlock.Uint64(), "latest processed block height is not correct.")
-
 }
 
 // Test that the JSON database can write and read from multiple chains concurrently. Write to any given chain are not concurrent.

--- a/database/json_file_storage_test.go
+++ b/database/json_file_storage_test.go
@@ -40,11 +40,11 @@ func TestConcurrentWriteReadSingleChain(t *testing.T) {
 
 	latestSeenBlockData, err := jsonStorage.Get(networks[0], []byte(LatestSeenBlockKey))
 	if err != nil {
-		t.Fatal(fmt.Sprintf("failed to retrieve from JSON storage. err: %v", err))
+		t.Fatalf("failed to retrieve from JSON storage. err: %v", err)
 	}
 	latestSeenBlock, success := new(big.Int).SetString(string(latestSeenBlockData), 10)
 	if !success {
-		t.Fatal(fmt.Sprintf("failed to convert latest block to big.Int. err: %v", err))
+		t.Fatalf("failed to convert latest block to big.Int. err: %v", err)
 	}
 	assert.Equal(t, finalTargetValue, latestSeenBlock.Uint64(), "latest seen block height is not correct.")
 
@@ -80,11 +80,11 @@ func TestConcurrentWriteReadMultipleChains(t *testing.T) {
 	for i, id := range networks {
 		latestSeenBlockData, err := jsonStorage.Get(id, []byte(LatestSeenBlockKey))
 		if err != nil {
-			t.Fatal(fmt.Sprintf("failed to retrieve from JSON storage. networkID: %d err: %v", i, err))
+			t.Fatalf("failed to retrieve from JSON storage. networkID: %d err: %v", i, err)
 		}
 		latestSeenBlock, success := new(big.Int).SetString(string(latestSeenBlockData), 10)
 		if !success {
-			t.Fatal(fmt.Sprintf("failed to convert latest block to big.Int. err: %v", err))
+			t.Fatalf("failed to convert latest block to big.Int. err: %v", err)
 		}
 		assert.Equal(t, finalTargetValue, latestSeenBlock.Uint64(), fmt.Sprintf("latest seen block height is not correct. networkID: %d", i))
 	}

--- a/database/json_file_storage_test.go
+++ b/database/json_file_storage_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package database
 
 import (

--- a/database/json_file_storage_test.go
+++ b/database/json_file_storage_test.go
@@ -38,15 +38,15 @@ func TestConcurrentWriteReadSingleChain(t *testing.T) {
 	finalTargetValue := uint64(11)
 	testWrite(jsonStorage, networks[0], finalTargetValue)
 
-	latestSeenBlockData, err := jsonStorage.Get(networks[0], []byte(LatestSeenBlockKey))
+	latestProcessedBlockData, err := jsonStorage.Get(networks[0], []byte(LatestProcessedBlockKey))
 	if err != nil {
 		t.Fatalf("failed to retrieve from JSON storage. err: %v", err)
 	}
-	latestSeenBlock, success := new(big.Int).SetString(string(latestSeenBlockData), 10)
+	latestProcessedBlock, success := new(big.Int).SetString(string(latestProcessedBlockData), 10)
 	if !success {
 		t.Fatalf("failed to convert latest block to big.Int. err: %v", err)
 	}
-	assert.Equal(t, finalTargetValue, latestSeenBlock.Uint64(), "latest seen block height is not correct.")
+	assert.Equal(t, finalTargetValue, latestProcessedBlock.Uint64(), "latest processed block height is not correct.")
 
 }
 
@@ -78,15 +78,15 @@ func TestConcurrentWriteReadMultipleChains(t *testing.T) {
 	}
 
 	for i, id := range networks {
-		latestSeenBlockData, err := jsonStorage.Get(id, []byte(LatestSeenBlockKey))
+		latestProcessedBlockData, err := jsonStorage.Get(id, []byte(LatestProcessedBlockKey))
 		if err != nil {
 			t.Fatalf("failed to retrieve from JSON storage. networkID: %d err: %v", i, err)
 		}
-		latestSeenBlock, success := new(big.Int).SetString(string(latestSeenBlockData), 10)
+		latestProcessedBlock, success := new(big.Int).SetString(string(latestProcessedBlockData), 10)
 		if !success {
 			t.Fatalf("failed to convert latest block to big.Int. err: %v", err)
 		}
-		assert.Equal(t, finalTargetValue, latestSeenBlock.Uint64(), fmt.Sprintf("latest seen block height is not correct. networkID: %d", i))
+		assert.Equal(t, finalTargetValue, latestProcessedBlock.Uint64(), fmt.Sprintf("latest processed block height is not correct. networkID: %d", i))
 	}
 }
 
@@ -110,7 +110,7 @@ func setupJsonStorage(t *testing.T, networks []ids.ID) *JSONFileStorage {
 
 func testWrite(storage *JSONFileStorage, chainID ids.ID, height uint64) {
 	fmt.Println(chainID, height)
-	err := storage.Put(chainID, []byte(LatestSeenBlockKey), []byte(strconv.FormatUint(height, 10)))
+	err := storage.Put(chainID, []byte(LatestProcessedBlockKey), []byte(strconv.FormatUint(height, 10)))
 	if err != nil {
 		fmt.Printf("failed to put data: %v", err)
 		return

--- a/database/json_file_storage_test.go
+++ b/database/json_file_storage_test.go
@@ -1,0 +1,75 @@
+package database
+
+import (
+	"fmt"
+	"math/big"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConcurrentWriteRead(t *testing.T) {
+	networks := []ids.ID{
+		ids.GenerateTestID(),
+		ids.GenerateTestID(),
+		ids.GenerateTestID(),
+	}
+	jsonStorage := setupJsonStorage(t, networks)
+
+	// Test writing to the JSON database concurrently.
+	wg := sync.WaitGroup{}
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			testWrite(jsonStorage, networks[0], uint64(0))
+			testWrite(jsonStorage, networks[1], uint64(1))
+			testWrite(jsonStorage, networks[2], uint64(2))
+		}()
+	}
+	wg.Wait()
+
+	for i, id := range networks {
+		latestSeenBlockData, err := jsonStorage.Get(id, []byte(LatestSeenBlockKey))
+		if err != nil {
+			t.Fatal(fmt.Sprintf("failed to retrieve from JSON storage. networkID: %d err: %v", i, err))
+		}
+		latestSeenBlock, success := new(big.Int).SetString(string(latestSeenBlockData), 10)
+		if !success {
+			t.Fatal(fmt.Sprintf("failed to convert latest block to big.Int. err: %v", err))
+		}
+		assert.Equal(t, uint64(i), latestSeenBlock.Uint64(), fmt.Sprintf("latest seen block height is not correct. networkID: %d", i))
+	}
+}
+
+func setupJsonStorage(t *testing.T, networks []ids.ID) *JSONFileStorage {
+	logger := logging.NewLogger(
+		"awm-relayer-test",
+		logging.NewWrappedCore(
+			logging.Info,
+			os.Stdout,
+			logging.JSON.ConsoleEncoder(),
+		),
+	)
+	storageDir := t.TempDir()
+
+	jsonStorage, err := NewJSONFileStorage(logger, storageDir, networks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return jsonStorage
+}
+
+func testWrite(storage *JSONFileStorage, chainID ids.ID, height uint64) {
+	fmt.Println(chainID, height)
+	err := storage.Put(chainID, []byte(LatestSeenBlockKey), []byte(strconv.FormatUint(height, 10)))
+	if err != nil {
+		fmt.Printf("failed to put data: %v", err)
+		return
+	}
+}

--- a/database/json_file_storage_test.go
+++ b/database/json_file_storage_test.go
@@ -13,7 +13,42 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConcurrentWriteRead(t *testing.T) {
+// Test that the JSON database can write and read to a single chain concurrently.
+func TestConcurrentWriteReadSingleChain(t *testing.T) {
+	networks := []ids.ID{
+		ids.GenerateTestID(),
+	}
+	jsonStorage := setupJsonStorage(t, networks)
+
+	// Test writing to the JSON database concurrently.
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			testWrite(jsonStorage, networks[0], uint64(i))
+		}()
+	}
+	wg.Wait()
+
+	// Write one final time to ensure that concurrent writes don't cause any issues.
+	finalTargetValue := uint64(11)
+	testWrite(jsonStorage, networks[0], finalTargetValue)
+
+	latestSeenBlockData, err := jsonStorage.Get(networks[0], []byte(LatestSeenBlockKey))
+	if err != nil {
+		t.Fatal(fmt.Sprintf("failed to retrieve from JSON storage. err: %v", err))
+	}
+	latestSeenBlock, success := new(big.Int).SetString(string(latestSeenBlockData), 10)
+	if !success {
+		t.Fatal(fmt.Sprintf("failed to convert latest block to big.Int. err: %v", err))
+	}
+	assert.Equal(t, finalTargetValue, latestSeenBlock.Uint64(), "latest seen block height is not correct.")
+
+}
+
+// Test that the JSON database can write and read from multiple chains concurrently. Write to any given chain are not concurrent.
+func TestConcurrentWriteReadMultipleChains(t *testing.T) {
 	networks := []ids.ID{
 		ids.GenerateTestID(),
 		ids.GenerateTestID(),
@@ -25,14 +60,19 @@ func TestConcurrentWriteRead(t *testing.T) {
 	wg := sync.WaitGroup{}
 	for i := 0; i < 3; i++ {
 		wg.Add(1)
+		index := i
 		go func() {
 			defer wg.Done()
-			testWrite(jsonStorage, networks[0], uint64(0))
-			testWrite(jsonStorage, networks[1], uint64(1))
-			testWrite(jsonStorage, networks[2], uint64(2))
+			testWrite(jsonStorage, networks[index], uint64(index))
 		}()
 	}
 	wg.Wait()
+
+	// Write one final time to ensure that concurrent writes don't cause any issues.
+	finalTargetValue := uint64(3)
+	for _, network := range networks {
+		testWrite(jsonStorage, network, finalTargetValue)
+	}
 
 	for i, id := range networks {
 		latestSeenBlockData, err := jsonStorage.Get(id, []byte(LatestSeenBlockKey))
@@ -43,7 +83,7 @@ func TestConcurrentWriteRead(t *testing.T) {
 		if !success {
 			t.Fatal(fmt.Sprintf("failed to convert latest block to big.Int. err: %v", err))
 		}
-		assert.Equal(t, uint64(i), latestSeenBlock.Uint64(), fmt.Sprintf("latest seen block height is not correct. networkID: %d", i))
+		assert.Equal(t, finalTargetValue, latestSeenBlock.Uint64(), fmt.Sprintf("latest seen block height is not correct. networkID: %d", i))
 	}
 }
 

--- a/main/main.go
+++ b/main/main.go
@@ -34,8 +34,6 @@ const (
 	defaultErrorChanSize = 1000
 	defaultApiPort       = 8080
 	defaultMetricsPort   = 9090
-
-	defaultStorageLocation = "~/.awm-relayer"
 )
 
 func main() {
@@ -153,7 +151,7 @@ func main() {
 	}
 
 	// Initialize the database
-	db, err := database.NewJSONFileStorage(logger, defaultStorageLocation, sourceChainIDs)
+	db, err := database.NewJSONFileStorage(logger, cfg.StorageLocation, sourceChainIDs)
 	if err != nil {
 		logger.Error(
 			"Failed to create database",

--- a/main/main.go
+++ b/main/main.go
@@ -31,9 +31,8 @@ import (
 )
 
 const (
-	defaultErrorChanSize = 1000
-	defaultApiPort       = 8080
-	defaultMetricsPort   = 9090
+	defaultApiPort     = 8080
+	defaultMetricsPort = 9090
 )
 
 func main() {
@@ -203,13 +202,11 @@ func runRelayer(logger logging.Logger,
 		"Creating relayer",
 		zap.String("chainID", sourceSubnetInfo.ChainID),
 	)
-	errorChan := make(chan error, defaultErrorChanSize)
 
 	relayer, subscriber, err := relayer.NewRelayer(
 		logger,
 		db,
 		sourceSubnetInfo,
-		errorChan,
 		pChainClient,
 		network,
 		responseChan,
@@ -265,13 +262,6 @@ func runRelayer(logger logging.Logger,
 				)
 				return
 			}
-		case err := <-errorChan:
-			logger.Error(
-				"Relayer goroutine stopped with error. Relayer goroutine exiting.",
-				zap.String("originChainID", sourceSubnetInfo.ChainID),
-				zap.Error(err),
-			)
-			return
 		}
 	}
 }

--- a/peers/external_handler.go
+++ b/peers/external_handler.go
@@ -71,17 +71,8 @@ func NewRelayerExternalHandler(
 // async, we must call OnFinishedHandling manually across all code paths.
 //
 // This diagram illustrates how HandleInbound forwards relevant AppResponses to the corresponding Teleporter message relayer.
-// On startup, one TeleporterRelayer goroutine is created per source subnet, which listens to the subscriber for cross-chain messages
-// When a cross-chain message is picked up by a TeleporterRelayer, a teleporterMessageRelayer goroutine is created and closed
-// once the cross-chain message is delivered. Messages are routed through the resulting tree structure:
-//
-// 								  TeleporterRelayer/source subnet       teleporterMessageRelayer/Teleporter message
-//
-//                       		{ TeleporterRelayer.responseChan --...  { teleporterMessageRelayer.messageResponseChan (consumer)
-// HandleInbound (producer) --->{ TeleporterRelayer.responseChan ------>{ teleporterMessageRelayer.messageResponseChan (consumer)
-//                       		{			  ...					    {						...
-//                       		{ TeleporterRelayer.responseChan --...  { teleporterMessageRelayer.messageResponseChan (consumer)
-
+// On startup, one Relayer goroutine is created per source subnet, which listens to the subscriber for cross-chain messages
+// When a cross-chain message is picked up by a Relayer, HandleInbound routes AppResponses traffic to the appropriate Relayer
 func (h *RelayerExternalHandler) HandleInbound(_ context.Context, inboundMessage message.InboundMessage) {
 	h.log.Debug(
 		"receiving message",

--- a/relayer/message_relayer.go
+++ b/relayer/message_relayer.go
@@ -76,7 +76,7 @@ func newMessageRelayer(
 	}
 }
 
-func (r *messageRelayer) run(warpMessageInfo *vmtypes.WarpMessageInfo, requestID uint32, messageManager messages.MessageManager) {
+func (r *messageRelayer) relayMessage(warpMessageInfo *vmtypes.WarpMessageInfo, requestID uint32, messageManager messages.MessageManager) error {
 	shouldSend, err := messageManager.ShouldSendMessage(warpMessageInfo, r.destinationChainID)
 	if err != nil {
 		r.logger.Error(
@@ -86,12 +86,11 @@ func (r *messageRelayer) run(warpMessageInfo *vmtypes.WarpMessageInfo, requestID
 
 		r.incFailedRelayMessageCount("failed to check if message should be sent")
 
-		r.relayer.errorChan <- err
-		return
+		return err
 	}
 	if !shouldSend {
 		r.logger.Info("Message should not be sent")
-		return
+		return nil
 	}
 
 	startCreateSignedMessageTime := time.Now()
@@ -103,8 +102,7 @@ func (r *messageRelayer) run(warpMessageInfo *vmtypes.WarpMessageInfo, requestID
 			zap.Error(err),
 		)
 		r.incFailedRelayMessageCount("failed to create signed warp message")
-		r.relayer.errorChan <- err
-		return
+		return err
 	}
 
 	// create signed message latency (ms)
@@ -117,14 +115,14 @@ func (r *messageRelayer) run(warpMessageInfo *vmtypes.WarpMessageInfo, requestID
 			zap.Error(err),
 		)
 		r.incFailedRelayMessageCount("failed to send warp message")
-		r.relayer.errorChan <- err
-		return
+		return err
 	}
 	r.logger.Info(
 		"Finished relaying message to destination chain",
 		zap.String("destinationChainID", r.destinationChainID.String()),
 	)
 	r.incSuccessfulRelayMessageCount()
+	return nil
 }
 
 // Run collects signatures from nodes by directly querying them via AppRequest, then aggregates the signatures, and constructs the signed warp message.

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -125,21 +125,21 @@ func NewRelayer(
 	}
 
 	// Get the latest processed block height from the database.
-	latestProcessedBlockData, err := r.db.Get(r.sourceChainID, []byte(database.LatestProcessedBlockKey))
+	latestSeenBlockData, err := r.db.Get(r.sourceChainID, []byte(database.LatestSeenBlockKey))
 	if err != nil {
 		r.logger.Warn("failed to get latest block from database", zap.Error(err))
 		return nil, nil, err
 	}
-	latestProcessedBlock, success := new(big.Int).SetString(string(latestProcessedBlockData), 10)
+	latestSeenBlock, success := new(big.Int).SetString(string(latestSeenBlockData), 10)
 	if !success {
 		r.logger.Error("failed to convert latest block to big.Int", zap.Error(err))
 		return nil, nil, err
 	}
 
-	// Back-process all warp messages from the latest processed block to the latest block
+	// Back-process all warp messages from the latest seen block to the latest block
 	// This will query the node for any logs that match the filter query from the stored block height,
 	// and process the contained warp messages. If initialization fails, continue with normal relayer operation, but log the error.
-	err = sub.ProcessFromHeight(latestProcessedBlock)
+	err = sub.ProcessFromHeight(latestSeenBlock)
 	if err != nil {
 		logger.Warn(
 			"Encountered an error when processing historical blocks. Continuing to normal relaying operation.",

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -172,8 +172,7 @@ func NewRelayer(
 	return nil, nil, err
 }
 
-// RelayMessage relays a single warp message to the destination chain. Warp message relay requests are concurrent with each other,
-// and synchronized by relayer.
+// RelayMessage relays a single warp message to the destination chain. Warp message relay requests from the same origin chain are processed serially
 func (r *Relayer) RelayMessage(warpLogInfo *vmtypes.WarpLogInfo, metrics *MessageRelayerMetrics, messageCreator message.Creator) error {
 	r.logger.Info(
 		"Relaying message",

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -48,7 +48,6 @@ func NewRelayer(
 	responseChan chan message.InboundMessage,
 	destinationClients map[ids.ID]vms.DestinationClient,
 ) (*Relayer, vms.Subscriber, error) {
-
 	sub := vms.NewSubscriber(logger, sourceSubnetInfo, db)
 
 	subnetID, err := ids.FromString(sourceSubnetInfo.SubnetID)

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -152,7 +152,7 @@ func NewRelayer(
 			zap.String("chainID", r.sourceChainID.String()),
 		)
 
-		err := sub.UpdateLatestProcessedBlock()
+		err := sub.SetProcessedBlockHeightToLatest()
 		if err != nil {
 			logger.Warn(
 				"Failed to update latest processed block. Continuing to normal relaying operation",

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -239,7 +239,9 @@ func (r *Relayer) RelayMessage(warpLogInfo *vmtypes.WarpLogInfo, metrics *Messag
 	err = r.db.Put(r.sourceChainID, []byte(database.LatestSeenBlockKey), []byte(strconv.FormatUint(warpLogInfo.BlockNumber, 10)))
 	if err != nil {
 		r.logger.Error(
-			fmt.Sprintf("failed to put %s into database", database.LatestSeenBlockKey), zap.Error(err))
+			fmt.Sprintf("failed to put %s into database", database.LatestSeenBlockKey),
+			zap.Error(err),
+		)
 	}
 
 	return nil

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -125,7 +125,7 @@ func NewRelayer(
 		return nil, nil, err
 	}
 
-	// Get the latest processed block height from the database.
+	// Get the latest seen block height from the database.
 	var (
 		latestSeenBlockData []byte
 		latestSeenBlock     *big.Int // initialized to nil
@@ -141,7 +141,7 @@ func NewRelayer(
 		// If the database contains the latest seen block data, then  back-process all warp messages from the
 		// latest seen block to the latest block
 		// This will query the node for any logs that match the filter query from the stored block height,
-		r.logger.Info("latest processed block", zap.String("block", string(latestSeenBlockData)))
+		r.logger.Info("latest seen block", zap.String("block", string(latestSeenBlockData)))
 		var success bool
 		latestSeenBlock, success = new(big.Int).SetString(string(latestSeenBlockData), 10)
 		if !success {

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -111,14 +111,13 @@ func NewRelayer(
 	go r.RouteToMessageChannel()
 
 	// Initialize the subscriber. This will poll the node for any logs that match the filter query from the stored block height,
-	// and process the contained warp messages
+	// and process the contained warp messages. If initialization fails, continue with normal relayer operation, but log the error.
 	err = sub.Initialize()
 	if err != nil {
-		logger.Error(
-			"Failed to initialize subscriber",
+		logger.Warn(
+			"Encountered an error when initializing subscriber. Skipping initialization.",
 			zap.Error(err),
 		)
-		return nil, nil, err
 	}
 
 	err = sub.Subscribe()

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -128,7 +128,7 @@ func NewRelayer(
 		// If the database contains the latest seen block data, then back-process all warp messages from that block to the latest block
 		// Note that the latest seen block may have already been partially (or fully) processed by the relayer on a previous run. When
 		// processing a warp message in real time, which is when we update the latest seen block in the database, we have no way of knowing
-		// if that is the last warp message to process in the block
+		// if that is the last warp message in the block
 		latestSeenBlock, success := new(big.Int).SetString(string(latestSeenBlockData), 10)
 		if !success {
 			r.logger.Error("failed to convert latest block to big.Int", zap.Error(err))

--- a/vms/evm/contract_message.go
+++ b/vms/evm/contract_message.go
@@ -53,5 +53,5 @@ func (m *contractMessage) UnpackWarpMessage(unsignedMsgBytes []byte) (*vmtypes.W
 		WarpUnsignedMessage: unsignedMsg,
 		WarpPayload:         warpPayload.Payload,
 	}
-	return &messageInfo, err
+	return &messageInfo, nil
 }

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -176,7 +176,7 @@ func (s *subscriber) ProcessFromHeight(height *big.Int) error {
 		height = big.NewInt(0).Add(toBlock, big.NewInt(-MaxBlocksToProcess))
 	}
 
-	// Filter logs from the latest seen block to the latest block
+	// Filter logs from the latest processed block to the latest block
 	// Since initializationFilterQuery does not modify existing fields of warpFilterQuery,
 	// we can safely reuse warpFilterQuery with only a shallow copy
 	initializationFilterQuery := interfaces.FilterQuery{
@@ -226,9 +226,9 @@ func (s *subscriber) ProcessFromHeight(height *big.Int) error {
 	return nil
 }
 
-func (s *subscriber) UpdateLatestSeenBlock() error {
+func (s *subscriber) UpdateLatestProcessedBlock() error {
 	s.logger.Info(
-		"Updating latest seen block in database",
+		"Updating latest processed block in database",
 		zap.String("chainID", s.chainID.String()),
 	)
 	ethClient, err := ethclient.Dial(s.nodeRPCURL)
@@ -251,10 +251,10 @@ func (s *subscriber) UpdateLatestSeenBlock() error {
 		return err
 	}
 
-	err = s.db.Put(s.chainID, []byte(database.LatestSeenBlockKey), []byte(strconv.FormatUint(latestBlock, 10)))
+	err = s.db.Put(s.chainID, []byte(database.LatestProcessedBlockKey), []byte(strconv.FormatUint(latestBlock, 10)))
 	if err != nil {
 		s.logger.Error(
-			fmt.Sprintf("failed to put %s into database", database.LatestSeenBlockKey),
+			fmt.Sprintf("failed to put %s into database", database.LatestProcessedBlockKey),
 			zap.String("chainID", s.chainID.String()),
 			zap.Error(err),
 		)

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -164,7 +164,7 @@ func (s *subscriber) ProcessFromHeight(height *big.Int) error {
 
 	// Cap the number of blocks to process to MaxBlocksToProcess
 	toBlock := big.NewInt(0).SetUint64(latestBlock)
-	if height.Cmp(big.NewInt(0).Add(toBlock, big.NewInt(-MaxBlocksToProcess))) < 0 {
+	if height.Cmp(big.NewInt(0).Sub(toBlock, big.NewInt(MaxBlocksToProcess))) < 0 {
 		s.logger.Warn(
 			fmt.Sprintf("Requested to process too many blocks. Processing only the most recent %d blocks", MaxBlocksToProcess),
 			zap.String("requestedBlockHeight", height.String()),

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -235,9 +235,8 @@ func (s *subscriber) dialAndSubscribe() error {
 		return err
 	}
 
-	filterQuery := warpFilterQuery
 	evmLogs := make(chan types.Log, maxClientSubscriptionBuffer)
-	sub, err := ethClient.SubscribeFilterLogs(context.Background(), filterQuery, evmLogs)
+	sub, err := ethClient.SubscribeFilterLogs(context.Background(), warpFilterQuery, evmLogs)
 	if err != nil {
 		s.logger.Error(
 			"Failed to subscribe to logs",

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -166,7 +166,7 @@ func (s *subscriber) ProcessFromHeight(height *big.Int) error {
 	toBlock := big.NewInt(0).SetUint64(latestBlock)
 	if height.Cmp(big.NewInt(0).Add(toBlock, big.NewInt(-MaxBlocksToProcess))) < 0 {
 		s.logger.Warn(
-			fmt.Sprintf("Requested to process too many blocks. Processing only the most recent %s blocks", MaxBlocksToProcess),
+			fmt.Sprintf("Requested to process too many blocks. Processing only the most recent %d blocks", MaxBlocksToProcess),
 			zap.String("requestedBlockHeight", height.String()),
 			zap.String("latestBlockHeight", toBlock.String()),
 		)

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -254,9 +254,9 @@ func (s *subscriber) UpdateLatestSeenBlock() error {
 	err = s.db.Put(s.chainID, []byte(database.LatestSeenBlockKey), []byte(strconv.FormatUint(latestBlock, 10)))
 	if err != nil {
 		s.logger.Error(
-			fmt.Sprintf("failed to put %s into database",
-				zap.String("chainID", s.chainID.String()),
-				database.LatestSeenBlockKey), zap.Error(err),
+			fmt.Sprintf("failed to put %s into database", database.LatestSeenBlockKey),
+			zap.String("chainID", s.chainID.String()),
+			zap.Error(err),
 		)
 		return err
 	}

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -174,6 +174,11 @@ func (s *subscriber) Initialize() error {
 	}
 
 	// Queue each of the logs to be processed
+	s.logger.Info(
+		"Processing logs on initialization",
+		zap.String("fromBlockHeight", latestBlockHeight.String()),
+		zap.String("toBlockHeight", strconv.Itoa(int(latestBlock))),
+	)
 	for _, log := range logs {
 		messageInfo, err := NewWarpLogInfo(log)
 		if err != nil {

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -118,11 +118,10 @@ func (s *subscriber) forwardLogs() {
 		}
 		s.log <- *messageInfo
 
-		// Update the database with the latest block height
-		// TODO: Rather than updating the db when logs are received, we may want to consider updating the db when messages are successfully relayed
-		err = s.db.Put(s.chainID, []byte(database.LatestProcessedBlockKey), []byte(strconv.FormatUint(msgLog.BlockNumber, 10)))
+		// Update the database with the latest seen block height
+		err = s.db.Put(s.chainID, []byte(database.LatestSeenBlockKey), []byte(strconv.FormatUint(msgLog.BlockNumber, 10)))
 		if err != nil {
-			s.logger.Error(fmt.Sprintf("failed to put %s into database", database.LatestProcessedBlockKey), zap.Error(err))
+			s.logger.Error(fmt.Sprintf("failed to put %s into database", database.LatestSeenBlockKey), zap.Error(err))
 		}
 	}
 }
@@ -178,10 +177,10 @@ func (s *subscriber) ProcessFromHeight(height *big.Int) error {
 		s.log <- *messageInfo
 	}
 
-	// Update the database with the latest block height
-	err = s.db.Put(s.chainID, []byte(database.LatestProcessedBlockKey), []byte(strconv.FormatUint(latestBlock, 10)))
+	// Update the database with the latest seen block height
+	err = s.db.Put(s.chainID, []byte(database.LatestSeenBlockKey), []byte(strconv.FormatUint(latestBlock, 10)))
 	if err != nil {
-		s.logger.Error(fmt.Sprintf("failed to put %s into database", database.LatestProcessedBlockKey), zap.Error(err))
+		s.logger.Error(fmt.Sprintf("failed to put %s into database", database.LatestSeenBlockKey), zap.Error(err))
 		return err
 	}
 	return nil

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -132,14 +132,15 @@ func (s *subscriber) Initialize() error {
 		return err
 	}
 
+	// Get the latest processed block height from the database.
 	heightData, err := s.db.Get(s.chainID, []byte(database.LatestBlockHeightKey))
 	if err != nil {
-		s.logger.Error("failed to get latestBlockHeight from database", zap.Error(err))
+		s.logger.Warn("failed to get latest block from database", zap.Error(err))
 		return err
 	}
 	latestBlockHeight, success := new(big.Int).SetString(string(heightData), 10)
 	if !success {
-		s.logger.Error("failed to convert latestBlockHeight to big.Int", zap.Error(err))
+		s.logger.Error("failed to convert latest block to big.Int", zap.Error(err))
 		return err
 	}
 

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -215,7 +215,7 @@ func (s *subscriber) Subscribe() error {
 }
 
 func (s *subscriber) dialAndSubscribe() error {
-	// Dial the configured destination chain endpoint
+	// Dial the configured source chain endpoint
 	// This needs to be a websocket
 	ethClient, err := ethclient.Dial(s.nodeWSURL)
 	if err != nil {

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sort"
 	"strconv"
 	"time"
 
@@ -193,6 +194,14 @@ func (s *subscriber) ProcessFromHeight(height *big.Int) error {
 		)
 		return err
 	}
+
+	// Sort the logs in ascending block order. Order logs by index within blocks
+	sort.SliceStable(logs, func(i, j int) bool {
+		if logs[i].BlockNumber == logs[j].BlockNumber {
+			return logs[i].TxIndex < logs[j].TxIndex
+		}
+		return logs[i].BlockNumber < logs[j].BlockNumber
+	})
 
 	// Queue each of the logs to be processed
 	s.logger.Info(

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -198,7 +198,7 @@ func (s *subscriber) ProcessFromHeight(height *big.Int) error {
 	// Sort the logs in ascending block order. Order logs by index within blocks
 	sort.SliceStable(logs, func(i, j int) bool {
 		if logs[i].BlockNumber == logs[j].BlockNumber {
-			return logs[i].TxIndex < logs[j].TxIndex
+			return logs[i].Index < logs[j].Index
 		}
 		return logs[i].BlockNumber < logs[j].BlockNumber
 	})

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -213,7 +213,6 @@ func (s *subscriber) UpdateLatestSeenBlock() error {
 		return err
 	}
 
-	// Grab the latest block before filtering logs so we don't miss any before updating the db
 	latestBlock, err := ethClient.BlockNumber(context.Background())
 	if err != nil {
 		s.logger.Error(

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -116,6 +116,7 @@ func (s *subscriber) NewWarpLogInfo(log types.Log) (*vmtypes.WarpLogInfo, error)
 		SourceAddress:      log.Topics[3],
 		SourceTxID:         log.TxHash[:],
 		UnsignedMsgBytes:   log.Data,
+		BlockNumber:        log.BlockNumber,
 	}, nil
 }
 
@@ -131,12 +132,6 @@ func (s *subscriber) forwardLogs() {
 			continue
 		}
 		s.logsChan <- *messageInfo
-
-		// Update the database with the latest seen block height
-		err = s.db.Put(s.chainID, []byte(database.LatestSeenBlockKey), []byte(strconv.FormatUint(msgLog.BlockNumber, 10)))
-		if err != nil {
-			s.logger.Error(fmt.Sprintf("failed to put %s into database", database.LatestSeenBlockKey), zap.Error(err))
-		}
 	}
 }
 
@@ -209,12 +204,6 @@ func (s *subscriber) ProcessFromHeight(height *big.Int) error {
 		s.logsChan <- *messageInfo
 	}
 
-	// Update the database with the latest seen block height
-	err = s.db.Put(s.chainID, []byte(database.LatestSeenBlockKey), []byte(strconv.FormatUint(latestBlock, 10)))
-	if err != nil {
-		s.logger.Error(fmt.Sprintf("failed to put %s into database", database.LatestSeenBlockKey), zap.Error(err))
-		return err
-	}
 	return nil
 }
 

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -226,7 +226,7 @@ func (s *subscriber) ProcessFromHeight(height *big.Int) error {
 	return nil
 }
 
-func (s *subscriber) UpdateLatestProcessedBlock() error {
+func (s *subscriber) SetProcessedBlockHeightToLatest() error {
 	s.logger.Info(
 		"Updating latest processed block in database",
 		zap.String("chainID", s.chainID.String()),

--- a/vms/subscriber.go
+++ b/vms/subscriber.go
@@ -20,7 +20,7 @@ type Subscriber interface {
 	// ProcessFromHeight processes events from {height} to the latest block
 	ProcessFromHeight(height *big.Int) error
 
-	// UpdateLatestSeenBlock retreives the latest block from the chain and updates the database
+	// UpdateLatestSeenBlock retrieves the latest block from the chain and updates the database
 	UpdateLatestSeenBlock() error
 
 	// Subscribe registers a subscription. After Subscribe is called,

--- a/vms/subscriber.go
+++ b/vms/subscriber.go
@@ -13,7 +13,9 @@ import (
 	"github.com/ava-labs/awm-relayer/vms/vmtypes"
 )
 
-// Subscriber subscribes to VM events containing Warp message data
+// Subscriber subscribes to VM events containing Warp message data. The events written to the
+// channel returned by Logs() are assumed to be in block order. Logs within individual blocks
+// may be in any order.
 type Subscriber interface {
 	// ProcessFromHeight processes events from {height} to the latest block
 	ProcessFromHeight(height *big.Int) error

--- a/vms/subscriber.go
+++ b/vms/subscriber.go
@@ -13,7 +13,7 @@ import (
 
 // Subscriber subscribes to VM events containing Warp message data
 type Subscriber interface {
-	// Inialize the subscriber by processing any pending events
+	// Initialize the subscriber by processing any pending events
 	Initialize() error
 
 	// Subscribe registers a subscription. After Subscribe is called,

--- a/vms/subscriber.go
+++ b/vms/subscriber.go
@@ -18,6 +18,9 @@ type Subscriber interface {
 	// ProcessFromHeight processes events from {height} to the latest block
 	ProcessFromHeight(height *big.Int) error
 
+	// UpdateLatestSeenBlock retreives the latest block from the chain and updates the database
+	UpdateLatestSeenBlock() error
+
 	// Subscribe registers a subscription. After Subscribe is called,
 	// log events that match [filter] are written to the channel returned
 	// by Logs

--- a/vms/subscriber.go
+++ b/vms/subscriber.go
@@ -20,8 +20,8 @@ type Subscriber interface {
 	// ProcessFromHeight processes events from {height} to the latest block
 	ProcessFromHeight(height *big.Int) error
 
-	// UpdateLatestProcessedBlock retrieves the latest block from the chain and updates the database
-	UpdateLatestProcessedBlock() error
+	// SetProcessedBlockHeightToLatest retrieves the latest block from the chain and updates the database
+	SetProcessedBlockHeightToLatest() error
 
 	// Subscribe registers a subscription. After Subscribe is called,
 	// log events that match [filter] are written to the channel returned

--- a/vms/subscriber.go
+++ b/vms/subscriber.go
@@ -20,8 +20,8 @@ type Subscriber interface {
 	// ProcessFromHeight processes events from {height} to the latest block
 	ProcessFromHeight(height *big.Int) error
 
-	// UpdateLatestSeenBlock retrieves the latest block from the chain and updates the database
-	UpdateLatestSeenBlock() error
+	// UpdateLatestProcessedBlock retrieves the latest block from the chain and updates the database
+	UpdateLatestProcessedBlock() error
 
 	// Subscribe registers a subscription. After Subscribe is called,
 	// log events that match [filter] are written to the channel returned

--- a/vms/subscriber.go
+++ b/vms/subscriber.go
@@ -4,6 +4,8 @@
 package vms
 
 import (
+	"math/big"
+
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/awm-relayer/config"
 	"github.com/ava-labs/awm-relayer/database"
@@ -13,8 +15,8 @@ import (
 
 // Subscriber subscribes to VM events containing Warp message data
 type Subscriber interface {
-	// Initialize the subscriber by processing any pending events
-	Initialize() error
+	// ProcessFromHeight processes events from {height} to the latest block
+	ProcessFromHeight(height *big.Int) error
 
 	// Subscribe registers a subscription. After Subscribe is called,
 	// log events that match [filter] are written to the channel returned

--- a/vms/subscriber.go
+++ b/vms/subscriber.go
@@ -6,30 +6,37 @@ package vms
 import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/awm-relayer/config"
+	"github.com/ava-labs/awm-relayer/database"
 	"github.com/ava-labs/awm-relayer/vms/evm"
 	"github.com/ava-labs/awm-relayer/vms/vmtypes"
 )
 
 // Subscriber subscribes to VM events containing Warp message data
 type Subscriber interface {
+	// Inialize the subscriber by processing any pending events
+	Initialize() error
+
 	// Subscribe registers a subscription. After Subscribe is called,
 	// log events that match [filter] are written to the channel returned
 	// by Logs
 	Subscribe() error
+
 	// Logs returns the channel that the subscription writes events to
 	Logs() <-chan vmtypes.WarpLogInfo
+
 	// Err returns the channel that the subscription writes errors to
 	// If an error is sent to this channel, the subscription should be closed
 	Err() <-chan error
+
 	// Cancel cancels the subscription
 	Cancel()
 }
 
 // NewSubscriber returns a concrete Subscriber according to the VM specified by [subnetInfo]
-func NewSubscriber(logger logging.Logger, subnetInfo config.SourceSubnet) Subscriber {
+func NewSubscriber(logger logging.Logger, subnetInfo config.SourceSubnet, db database.RelayerDatabase) Subscriber {
 	switch config.ParseVM(subnetInfo.VM) {
 	case config.EVM:
-		return evm.NewSubscriber(logger, subnetInfo)
+		return evm.NewSubscriber(logger, subnetInfo, db)
 	default:
 		return nil
 	}

--- a/vms/vmtypes/message_info.go
+++ b/vms/vmtypes/message_info.go
@@ -17,4 +17,5 @@ type WarpLogInfo struct {
 	DestinationAddress common.Hash
 	SourceTxID         []byte
 	UnsignedMsgBytes   []byte
+	BlockNumber        uint64
 }


### PR DESCRIPTION
## Why this should be merged
Enables the relayer to process warp messages sent while the relayer was offline. Fixes https://github.com/ava-labs/awm-relayer/issues/14

## How this works
Adds a `ProcessFromHeight` method to `Subscriber`. The EVM implementation calls `eth_getLogs` to retrieve Warp logs since the last processed block. Adds JSON storage to persist the last processed block.

## How this was tested
CI, Teleporter integration tests, added unit tests for JSON storage, manual testing. Will circle back and add end-to-end tests once https://github.com/ava-labs/awm-relayer/issues/15 is complete.
