### PR TITLE
Portable BLST

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,5 +32,5 @@ jobs:
     - name: Run Relayer Unit Tests
       run: |
         cd awm-relayer
-        go test ./...
+        ./scripts/test.sh
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ To start developing on AWM Relayer, you'll need Golang >= v1.18.1.
 - Run the unit tests
 
 ```sh
-go test ./...
+./scripts/test.sh
 ```
 
 ### Continuous Integration (CI)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,13 +30,14 @@ if version_lt "$(go_version)" "$go_version_minimum"; then
 fi
 
 # Root directory
-AWM_RELAYER_PATH=$(
+RELAYER_PATH=$(
     cd "$(dirname "${BASH_SOURCE[0]}")"
     cd .. && pwd
 )
 
-# Load the versions
-source "$AWM_RELAYER_PATH"/scripts/versions.sh
+# Load the versions and constants
+source "$RELAYER_PATH"/scripts/versions.sh
+source "$RELAYER_PATH"/scripts/constants.sh
 
 if [[ $# -eq 1 ]]; then
     binary_path=$1

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -22,3 +22,12 @@ relayer_dockerhub_repo=${DOCKER_REPO:-"awm-relayer"}
 current_branch=$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match || true)
 
 git_commit=${RELAYER_COMMIT:-$( git rev-list -1 HEAD )}
+
+# Set the CGO flags to use the portable version of BLST
+#
+# We use "export" here instead of just setting a bash variable because we need
+# to pass this flag to all child processes spawned by the shell.
+export CGO_CFLAGS="-O -D__BLST_PORTABLE__"
+# While CGO_ENABLED doesn't need to be explicitly set, it produces a much more
+# clear error due to the default value change in go1.20.
+export CGO_ENABLED=1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Directory above this script
+RELAYER_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+
+source "$RELAYER_PATH"/scripts/constants.sh
+
+go test ./...


### PR DESCRIPTION
## Why this should be merged
Fixes cross-platform application and unit test execution by adding portable BLST flags. Otherwise, execution fails with `SIGILL`

## How this works
- Adds portable BLST flags to `constants.sh`
- Adds test entrypoint script `test.sh` that sources `constants.sh`

## How this was tested
CI, Teleporter integration tests