### PR TITLE
Add a Go linter to CI

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,7 +9,7 @@ on:
       - '*'
 
 jobs:
-  golang-linter:
+  golangci:
     runs-on: ubuntu-20.04
 
     steps:
@@ -28,5 +28,5 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: v1.51
-        working-directory: .
+        working-directory: ./awm-relayer
         args: --timeout 10m

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,18 +9,17 @@ on:
       - '*'
 
 jobs:
-  lint_test:
-    name: Lint
+  golang-linter:
     runs-on: ubuntu-20.04
 
     steps:
     - name: Checkout repository
-    uses: actions/checkout@v3
-    with:
-      path: awm-relayer
+      uses: actions/checkout@v3
+      with:
+        path: awm-relayer
 
     - name: Setup Go
-    - uses: actions/setup-go@v4
+      uses: actions/setup-go@v4
       with:
         go-version: '1.20.7'
         check-latest: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,33 @@
+# Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
+
+name: Run Golang Linter
+
+on:
+  push:
+    branches:
+      - '*'
+
+jobs:
+  lint_test:
+    name: Lint
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout repository
+    uses: actions/checkout@v3
+    with:
+      path: awm-relayer
+
+    - name: Setup Go
+    - uses: actions/setup-go@v4
+      with:
+        go-version: '1.20.7'
+        check-latest: true
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.51
+        working-directory: .
+        args: --timeout 10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,29 @@
+# This file configures github.com/golangci/golangci-lint.
+
+run:
+  timeout: 3m
+  tests: true
+  # skip auto-generated files.
+  skip-files:
+    - ".*mock.*"
+
+issues:
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
+
+linters:
+  disable-all: true
+  enable:
+    - goconst
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - unconvert
+    - unused
+    - whitespace
+
+linters-settings:
+  gofmt:
+    simplify: true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -351,8 +351,7 @@ func TestGetRelayerAccountPrivateKey_set_pk_with_global_env(t *testing.T) {
 		},
 		envSetter: func() {
 			// Overwrite the PK for the first subnet using an env var
-			varName := fmt.Sprintf("%s", accountPrivateKeyEnvVarName)
-			t.Setenv(varName, testPk2)
+			t.Setenv(accountPrivateKeyEnvVarName, testPk2)
 		},
 		expectedOverwritten: true,
 		resultVerifier: func(c Config) bool {

--- a/main/main.go
+++ b/main/main.go
@@ -284,7 +284,6 @@ func initMetrics() (prometheus.Gatherer, prometheus.Registerer, error) {
 	registry := prometheus.NewRegistry()
 	if err := gatherer.Register("app", registry); err != nil {
 		return nil, nil, err
-
 	}
 	return gatherer, registry, nil
 }

--- a/peers/external_handler.go
+++ b/peers/external_handler.go
@@ -133,7 +133,6 @@ func (h *RelayerExternalHandler) HandleInbound(_ context.Context, inboundMessage
 
 			h.responseChans[chainID] <- inboundMessage
 		}(inboundMessage, chainID)
-
 	} else {
 		inboundMessage.OnFinishedHandling()
 	}

--- a/relayer/message_relayer.go
+++ b/relayer/message_relayer.go
@@ -159,7 +159,7 @@ func (r *messageRelayer) createSignedMessage(requestID uint32) (*warp.Message, e
 	// If new peers are connected, AppRequests may fail while the handshake is in progress.
 	// In that case, AppRequests to those nodes will be retried in the next iteration of the retry loop.
 	nodeIDs := set.NewSet[ids.NodeID](len(nodeValidatorIndexMap))
-	for node, _ := range nodeValidatorIndexMap {
+	for node := range nodeValidatorIndexMap {
 		nodeIDs.Add(node)
 	}
 
@@ -426,7 +426,6 @@ func (r *messageRelayer) getCurrentCanonicalValidatorSet() ([]*warp.Validator, u
 func (r *messageRelayer) isValidSignatureResponse(
 	response message.InboundMessage,
 	pubKey *bls.PublicKey) (blsSignatureBuf, bool) {
-
 	// If the handler returned an error response, count the response and continue
 	if response.Op() == message.AppRequestFailedOp {
 		r.logger.Debug(

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -46,7 +46,6 @@ func NewRelayer(
 	responseChan chan message.InboundMessage,
 	destinationClients map[ids.ID]vms.DestinationClient,
 ) (*Relayer, vms.Subscriber, error) {
-
 	sub := vms.NewSubscriber(logger, sourceSubnetInfo)
 
 	subnetID, err := ids.FromString(sourceSubnetInfo.SubnetID)

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+golangci-lint run --path-prefix=. --timeout 3m

--- a/vms/evm/contract_message_test.go
+++ b/vms/evm/contract_message_test.go
@@ -7,43 +7,11 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/ava-labs/awm-relayer/config"
-	warpPayload "github.com/ava-labs/subnet-evm/warp/payload"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
-
-// Used to create a valid unsigned message for testing. Should not be used directly in tests.
-func createUnsignedMessage() *warp.UnsignedMessage {
-	sourceChainID, err := ids.FromString("yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp")
-	if err != nil {
-		return nil
-	}
-	destinationChainID, err := ids.FromString("11111111111111111111111111111111LpoYY")
-	if err != nil {
-		return nil
-	}
-
-	payload, err := warpPayload.NewAddressedPayload(
-		common.HexToAddress("27aE10273D17Cd7e80de8580A51f476960626e5f"),
-		common.Hash(destinationChainID),
-		common.HexToAddress("1234123412341234123412341234123412341234"),
-		[]byte{},
-	)
-	if err != nil {
-		return nil
-	}
-
-	unsignedMsg, err := warp.NewUnsignedMessage(0, sourceChainID, payload.Bytes())
-	if err != nil {
-		return nil
-	}
-	return unsignedMsg
-}
 
 func TestUnpack(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/vms/evm/contract_message_test.go
+++ b/vms/evm/contract_message_test.go
@@ -7,11 +7,44 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/ava-labs/awm-relayer/config"
+	warpPayload "github.com/ava-labs/subnet-evm/warp/payload"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
+
+// nolint: unused
+// Used to create a valid unsigned message for testing. Should not be used directly in tests.
+func createUnsignedMessage() *warp.UnsignedMessage {
+	sourceChainID, err := ids.FromString("yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp")
+	if err != nil {
+		return nil
+	}
+	destinationChainID, err := ids.FromString("11111111111111111111111111111111LpoYY")
+	if err != nil {
+		return nil
+	}
+
+	payload, err := warpPayload.NewAddressedPayload(
+		common.HexToAddress("27aE10273D17Cd7e80de8580A51f476960626e5f"),
+		common.Hash(destinationChainID),
+		common.HexToAddress("1234123412341234123412341234123412341234"),
+		[]byte{},
+	)
+	if err != nil {
+		return nil
+	}
+
+	unsignedMsg, err := warp.NewUnsignedMessage(0, sourceChainID, payload.Bytes())
+	if err != nil {
+		return nil
+	}
+	return unsignedMsg
+}
 
 func TestUnpack(t *testing.T) {
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
## Why this should be merged
- Add a linter for go files with set lint rules and a github workflow.

## How this works
- Use Github Action for running [golangci-lint](https://github.com/golangci/golangci-lint) 

## How this was tested
- CI