### PR TITLE
use docker build path context

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       # Needed for multi-platform builds
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -31,6 +31,7 @@ jobs:
       - name: Build and Push to Docker Hub
         uses: docker/build-push-action@v5
         with:
+          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: avaplatform/awm-relayer:${{ github.event.release.tag_name }}, avaplatform/awm-relayer:latest


### PR DESCRIPTION
## Why this should be merged
Release action for publish docker image is failing, this hopes to address and fix.

## How this works
for `build-push-action` [docs](https://github.com/docker/build-push-action/tree/v5/#git-context), specifies we use git context without the `checkout` action, or if we use `checkout` action we should pass in path `context`. So this PR is adding the path context since we do use `checkout` action.

## How this was tested
n/a

## How is this documented
n/a