### PR TITLE
separate info API cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 `"p-chain-api-url": string`
 - The URL of the Avalanche P-Chain API node to which the relayer will connect. Defaults to `https://api.avax.network`.
 
+`info-api-url": string`
+- The URL of the Avalanche API node to which the relayer will connect to get information about the network. The Info API must be enabled on the node.
+
 `"encrypt-connection": boolean`
 - Whether or not to encrypt the connection to the P-Chain API node. Defaults to `true`.
 

--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,7 @@ type Config struct {
 	LogLevel           string              `mapstructure:"log-level" json:"log-level"`
 	NetworkID          uint32              `mapstructure:"network-id" json:"network-id"`
 	PChainAPIURL       string              `mapstructure:"p-chain-api-url" json:"p-chain-api-url"`
+	InfoAPIURL         string              `mapstructure:"info-api-url" json:"info-api-url"`
 	EncryptConnection  bool                `mapstructure:"encrypt-connection" json:"encrypt-connection"`
 	StorageLocation    string              `mapstructure:"storage-location" json:"storage-location"`
 	SourceSubnets      []SourceSubnet      `mapstructure:"source-subnets" json:"source-subnets"`
@@ -109,6 +110,7 @@ func BuildConfig(v *viper.Viper) (Config, bool, error) {
 	cfg.LogLevel = v.GetString(LogLevelKey)
 	cfg.NetworkID = v.GetUint32(NetworkIDKey)
 	cfg.PChainAPIURL = v.GetString(PChainAPIURLKey)
+	cfg.InfoAPIURL = v.GetString(InfoAPIURLKey)
 	cfg.EncryptConnection = v.GetBool(EncryptConnectionKey)
 	cfg.StorageLocation = v.GetString(StorageLocationKey)
 	if err := v.UnmarshalKey(DestinationSubnetsKey, &cfg.DestinationSubnets); err != nil {
@@ -153,11 +155,17 @@ func BuildConfig(v *viper.Viper) (Config, bool, error) {
 		protocol = "http"
 	}
 
-	pChainapiUrl, err := utils.ConvertProtocol(cfg.PChainAPIURL, protocol)
+	pChainApiUrl, err := utils.ConvertProtocol(cfg.PChainAPIURL, protocol)
 	if err != nil {
 		return Config{}, false, err
 	}
-	cfg.PChainAPIURL = pChainapiUrl
+	cfg.PChainAPIURL = pChainApiUrl
+
+	infoApiUrl, err := utils.ConvertProtocol(cfg.InfoAPIURL, protocol)
+	if err != nil {
+		return Config{}, false, err
+	}
+	cfg.InfoAPIURL = infoApiUrl
 
 	globalConfig = cfg
 
@@ -172,6 +180,9 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("relayer not configured to relay to any subnets. A list of destination subnets must be provided in the configuration file")
 	}
 	if _, err := url.ParseRequestURI(c.PChainAPIURL); err != nil {
+		return err
+	}
+	if _, err := url.ParseRequestURI(c.InfoAPIURL); err != nil {
 		return err
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,6 +27,7 @@ var (
 		LogLevel:          "info",
 		NetworkID:         1337,
 		PChainAPIURL:      "http://test.avax.network",
+		InfoAPIURL:        "http://info.avax.network",
 		EncryptConnection: false,
 		SourceSubnets: []SourceSubnet{
 			{

--- a/config/keys.go
+++ b/config/keys.go
@@ -9,6 +9,7 @@ const (
 	LogLevelKey           = "log-level"
 	NetworkIDKey          = "network-id"
 	PChainAPIURLKey       = "p-chain-api-url"
+	InfoAPIURLKey         = "info-api-url"
 	SourceSubnetsKey      = "source-subnets"
 	DestinationSubnetsKey = "destination-subnets"
 	EncryptConnectionKey  = "encrypt-connection"

--- a/main/main.go
+++ b/main/main.go
@@ -103,7 +103,7 @@ func main() {
 		panic(err)
 	}
 
-	network, responseChans, err := peers.NewNetwork(logger, registerer, cfg.NetworkID, sourceSubnetIDs, sourceChainIDs, cfg.PChainAPIURL)
+	network, responseChans, err := peers.NewNetwork(logger, registerer, cfg.NetworkID, sourceSubnetIDs, sourceChainIDs, cfg.InfoAPIURL)
 	if err != nil {
 		logger.Error(
 			"Failed to create app request network",

--- a/tests/basic_relay.go
+++ b/tests/basic_relay.go
@@ -86,6 +86,7 @@ func BasicRelay() {
 		LogLevel:          logging.Info.LowerString(),
 		NetworkID:         peers.LocalNetworkID,
 		PChainAPIURL:      subnetAInfo.ChainNodeURIs[0],
+		InfoAPIURL:        subnetAInfo.ChainNodeURIs[0],
 		EncryptConnection: false,
 		StorageLocation:   storageLocation,
 		SourceSubnets: []config.SourceSubnet{


### PR DESCRIPTION
## Why this should be merged
Currently the P-Chain API URL passed in the config is used for two purposes:
- To get the canonical validator set for a subnet
- To establish peers in the app request network via the info API

The latter case requires the info API be enabled on the node. For the public RPC (`api.avax.network`), the info API is disabled.

## How this works
The change separates the Info API URL from the P-Chain API URL, giving each of the above use cases a dedicated URL. They may still be the same node, but we no longer require the info API be enabled on the P-Chain API node. 

## How this was tested
CI

## How is this documented
Modified `Configuration` section in README