### PR TITLE
Update dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,9 @@ updates:
       interval: "daily"
     ignore:
       # Update go-ethereum only via subnet-evm or avalanchego
-      - dependency-name: "go-ethereum"
+      - dependency-name: "github.com/ethereum/go-ethereum"
+      # Avalanchego is updated to stay compatible with subnet-evm
+      - dependency-name: "github.com/ava-labs/avalanchego"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Why this should be merged
The current dependabot ignore config is not correctly ignoring for `go-ethereum`, and we also want to ignore for avalanchego, since that version needs to be compatible with `subnet-evm` version

## How this works

## How this was tested

## How is this documented