### PR TITLE
Single source of truth for go version

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,9 +11,6 @@ on:
     branches:
       - "**"
 
-env:
-  GO_VERSION: "1.20.10"
-
 jobs:
   e2e_tests:
     name: e2e_tests
@@ -25,6 +22,11 @@ jobs:
         with:
           repository: ava-labs/subnet-evm
           ref: v0.5.8
+
+      - name: Set Go version
+        run: |
+          source ./scripts/versions.sh
+          GO_VERSION=$GO_VERSION >> $GITHUB_ENV
 
       - name: Setup Go
         uses: actions/setup-go@v4

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-      with:
-        path: awm-relayer
 
     - name: Set Go version
       run: |
@@ -32,5 +30,4 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: v1.51
-        working-directory: ./awm-relayer
         args: --timeout 10m

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,11 +18,15 @@ jobs:
       with:
         path: awm-relayer
 
+    - name: Set Go version
+      run: |
+        source ./scripts/versions.sh
+        GO_VERSION=$GO_VERSION >> $GITHUB_ENV
+
     - name: Setup Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20.10'
-        check-latest: true
+        go-version: ${{ env.GO_VERSION }}
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,15 +8,18 @@ on:
     branches:
       - "**"
 
-env:
-  GO_VERSION: "1.20.10"
-
 jobs:
   test_relayer:
     name: Unit tests
     runs-on: ubuntu-20.04
 
     steps:
+
+      - name: Set Go version
+        run: |
+          source ./scripts/versions.sh
+          GO_VERSION=$GO_VERSION >> $GITHUB_ENV
+          
       - name: Setup Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,9 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-
+      - name: Checkout awm-relayer repository
+        uses: actions/checkout@v4
+        
       - name: Set Go version
         run: |
           source ./scripts/versions.sh
@@ -24,9 +26,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Checkout awm-relayer repository
-        uses: actions/checkout@v4
 
       - name: Run Relayer Unit Tests
         run: ./scripts/test.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
+ARG GO_VERSION
+
 ### Build Stage ###
-FROM golang:1.20.8-bullseye as build
+FROM golang:${GO_VERSION}-bullseye as build
 
 WORKDIR /go/src
 # Copy the code into the container
@@ -9,7 +11,7 @@ RUN go mod tidy
 RUN bash ./scripts/build.sh
 
 ### RUN Stage ###
-FROM golang:1.20.8
+FROM golang:${GO_VERSION}
 COPY --from=build /go/src/build/awm-relayer /usr/bin/awm-relayer
 EXPOSE 8080
 USER 1001

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -49,5 +49,5 @@ else
 fi
 
 # Build AWM Relayer, which is run as a standalone process
-echo "Building AWM Relayer Version: $AWM_RELAYER_VERSION at $binary_path"
+echo "Building AWM Relayer Version: $(git describe --tags --abbrev=0) at $binary_path"
 go build -o "$binary_path" "main/"*.go

--- a/scripts/build_local_image.sh
+++ b/scripts/build_local_image.sh
@@ -13,6 +13,7 @@ RELAYER_PATH=$(
 )
 # Load the constants
 source "$RELAYER_PATH"/scripts/constants.sh
+source "$RELAYER_PATH"/scripts/versions.sh
 
 # WARNING: this will use the most recent commit even if there are un-committed changes present
 full_commit_hash="$(git --git-dir="$RELAYER_PATH/.git" rev-parse HEAD)"

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -2,9 +2,24 @@
 # Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 # See the file LICENSE for licensing terms.
 
-# Set up the versions to be used
-AWM_RELAYER_VERSION=${AWM_RELAYER_VERSION:-'v0.2.2'}
-SUBNET_EVM_VERSION=${SUBNET_EVM_VERSION:-'v0.5.8'}
+# The go version for this project is set from a combination of major.minor from go.mod and the patch version set here.
+GO_PATCH_VERSION=10
+
+RELAYER_PATH=$(
+  cd "$(dirname "${BASH_SOURCE[0]}")"
+  cd .. && pwd
+)
+
+# Pass in the full name of the dependency.
+# Parses go.mod for a matching entry and extracts the version number.
+function getDepVersion() {
+    grep -m1 "^\s*$1" $RELAYER_PATH/go.mod | cut -d ' ' -f2
+}
+
+# This needs to be exported to be picked up by the dockerfile.
+export GO_VERSION=${GO_VERSION:-$(getDepVersion go).$GO_PATCH_VERSION}
+
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.10.14'}
-GINKGO_VERSION=${GINKGO_VERSION:-'v2.2.0'}
+AVALANCHEGO_VERSION=${AVALANCHEGO_VERSION:-$(getDepVersion github.com/ava-labs/avalanchego)}
+GINKGO_VERSION=${GINKGO_VERSION:-$(getDepVersion github.com/onsi/ginkgo/v2)}
+SUBNET_EVM_VERSION=${SUBNET_EVM_VERSION:-$(getDepVersion github.com/ava-labs/subnet-evm)}


### PR DESCRIPTION
## Why this should be merged
Creates a single source of truth for pulling the golang version, as well as deps like ginkgo and subnet-evm.

## How this works

## How this was tested

## How is this documented