### PR TITLE
Golang 1.20.12

### DIFF
--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -3,7 +3,7 @@
 # See the file LICENSE for licensing terms.
 
 # The go version for this project is set from a combination of major.minor from go.mod and the patch version set here.
-GO_PATCH_VERSION=10
+GO_PATCH_VERSION=12
 
 RELAYER_PATH=$(
   cd "$(dirname "${BASH_SOURCE[0]}")"


### PR DESCRIPTION
## Why this should be merged
Addresses [CVE-2023-39326](https://www.cve.org/CVERecord?id=CVE-2023-39326).

## How this works
Updates the minimum golang version to include https://github.com/golang/go/issues/64434.

## How this was tested
CI

## How is this documented
N/A