### PR TITLE
Pass in GO_VERSION explicitly to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-ARG GO_VERSION
-
 ### Build Stage ###
+ARG GO_VERSION
 FROM golang:${GO_VERSION}-bullseye as build
 
 WORKDIR /go/src
@@ -11,6 +10,7 @@ RUN go mod tidy
 RUN bash ./scripts/build.sh
 
 ### RUN Stage ###
+ARG GO_VERSION
 FROM golang:${GO_VERSION}
 COPY --from=build /go/src/build/awm-relayer /usr/bin/awm-relayer
 EXPOSE 8080

--- a/scripts/build_local_image.sh
+++ b/scripts/build_local_image.sh
@@ -22,4 +22,5 @@ commit_hash="${full_commit_hash::8}"
 echo "Building Docker Image with tags: $relayer_dockerhub_repo:$commit_hash , $relayer_dockerhub_repo:$current_branch"
 docker build -t "$relayer_dockerhub_repo:$commit_hash" \
         -t "$relayer_dockerhub_repo:$current_branch" \
-        "$RELAYER_PATH" -f "$RELAYER_PATH/Dockerfile"
+        "$RELAYER_PATH" -f "$RELAYER_PATH/Dockerfile" \
+        --build-arg GO_VERSION=$GO_VERSION


### PR DESCRIPTION
## Why this should be merged
Docker Compose files will pick up exported env vars, but plain dockerfiles won't, so we have to specify it to pass it in.

Also an `ARG` in a dockerfile's scope only lasts until the next `FROM` directive.

## How this works

## How this was tested

## How is this documented