### PR TITLE
Set go version for dockerfile release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,11 +27,17 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Set Go version
+        run: |
+          source ./scripts/versions.sh
+          GO_VERSION=$GO_VERSION >> $GITHUB_ENV
 
       - name: Build and Push to Docker Hub
         uses: docker/build-push-action@v5
         with:
           context: .
+          build-args: GO_VERSION=${{ env.GO_VERSION }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: avaplatform/awm-relayer:${{ github.event.release.tag_name }}, avaplatform/awm-relayer:latest


### PR DESCRIPTION
## Why this should be merged
The release workflow needs the golang version to be set so it can grab the right docker images to build with.

## How this works

## How this was tested

## How is this documented