### PR TITLE
Set go version properly in workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,12 +17,6 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - name: Checkout subnet-evm repository
-        uses: actions/checkout@v4
-        with:
-          repository: ava-labs/subnet-evm
-          ref: v0.5.9
-
       - name: Set Go version
         run: |
           source ./scripts/versions.sh
@@ -32,6 +26,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      - name: Checkout subnet-evm repository
+        uses: actions/checkout@v4
+        with:
+          repository: ava-labs/subnet-evm
+          ref: v0.5.8
 
       - name: Install AvalancheGo Release
         run: BASEDIR=/tmp/e2e-test AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego ./scripts/install_avalanchego_release.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,16 +17,21 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+      - name: Checkout awm-relayer repository
+        uses: actions/checkout@v4
+
+      - name: Set versions
+        run: |
+          source ./scripts/versions.sh
+          echo SUBNET_EVM_VERSION=$SUBNET_EVM_VERSION >> $GITHUB_ENV
+          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
+
       - name: Checkout subnet-evm repository
         uses: actions/checkout@v4
         with:
           repository: ava-labs/subnet-evm
-          ref: v0.5.8
-
-      - name: Set Go version
-        run: |
-          source ./scripts/versions.sh
-          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
+          ref: ${{ env.SUBNET_EVM_VERSION }}
+          path: subnet-evm
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -34,13 +39,10 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Install AvalancheGo Release
-        run: BASEDIR=/tmp/e2e-test AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego ./scripts/install_avalanchego_release.sh
+        run: BASEDIR=/tmp/e2e-test AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego ./subnet-evm/scripts/install_avalanchego_release.sh
 
       - name: Build Subnet-EVM Plugin Binary
-        run: ./scripts/build.sh /tmp/e2e-test/avalanchego/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
-
-      - name: Checkout awm-relayer repository
-        uses: actions/checkout@v4
+        run: ./subnet-evm/scripts/build.sh /tmp/e2e-test/avalanchego/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
 
       - name: Run E2E Tests
         run: AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego DATA_DIR=/tmp/e2e-test/data ./scripts/e2e_test.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,21 +17,16 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - name: Checkout awm-relayer repository
-        uses: actions/checkout@v4
-
-      - name: Set versions
-        run: |
-          source ./scripts/versions.sh
-          echo SUBNET_EVM_VERSION=$SUBNET_EVM_VERSION >> $GITHUB_ENV
-          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
-
       - name: Checkout subnet-evm repository
         uses: actions/checkout@v4
         with:
           repository: ava-labs/subnet-evm
-          ref: v0.5.8
-          path: subnet-evm
+          ref: v0.5.9
+
+      - name: Set Go version
+        run: |
+          source ./scripts/versions.sh
+          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -39,10 +34,13 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Install AvalancheGo Release
-        run: BASEDIR=/tmp/e2e-test AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego ./subnet-evm/scripts/install_avalanchego_release.sh
+        run: BASEDIR=/tmp/e2e-test AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego ./scripts/install_avalanchego_release.sh
 
       - name: Build Subnet-EVM Plugin Binary
-        run: ./subnet-evm/scripts/build.sh /tmp/e2e-test/avalanchego/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
+        run: ./scripts/build.sh /tmp/e2e-test/avalanchego/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
+
+      - name: Checkout awm-relayer repository
+        uses: actions/checkout@v4
 
       - name: Run E2E Tests
         run: AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego DATA_DIR=/tmp/e2e-test/data ./scripts/e2e_test.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           source ./scripts/versions.sh
           echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
+          echo SUBNET_EVM_VERSION=$SUBNET_EVM_VERSION >> $GITHUB_ENV
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -34,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ava-labs/subnet-evm
-          ref: v0.5.8
+          ref: v0.5.8 # TODO set with env.SUBNET_EVM_VERSION
 
       - name: Install AvalancheGo Release
         run: BASEDIR=/tmp/e2e-test AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego ./scripts/install_avalanchego_release.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set Go version
         run: |
           source ./scripts/versions.sh
-          GO_VERSION=$GO_VERSION >> $GITHUB_ENV
+          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ava-labs/subnet-evm
-          ref: ${{ env.SUBNET_EVM_VERSION }}
+          ref: v0.5.8
           path: subnet-evm
 
       - name: Setup Go

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+      - name: Checkout awm-relayer repository
+        uses: actions/checkout@v4
+        
       - name: Set Go version
         run: |
           source ./scripts/versions.sh

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set Go version
       run: |
         source ./scripts/versions.sh
-        GO_VERSION=$GO_VERSION >> $GITHUB_ENV
+        echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
 
     - name: Setup Go
       uses: actions/setup-go@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Set Go version
         run: |
           source ./scripts/versions.sh
-          GO_VERSION=$GO_VERSION >> $GITHUB_ENV
+          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
 
       - name: Build and Push to Docker Hub
         uses: docker/build-push-action@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set Go version
         run: |
           source ./scripts/versions.sh
-          GO_VERSION=$GO_VERSION >> $GITHUB_ENV
+          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
           
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-To start developing on AWM Relayer, you'll need Golang >= v1.18.1.
+To start developing on AWM Relayer, you'll need Golang >= v1.20.12.
 
 ## Issues
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/awm-relayer
 
-go 1.18
+go 1.20
 
 require (
 	github.com/ava-labs/avalanchego v1.10.15

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,8 +6,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-go_version_minimum="1.18.1"
-
 go_version() {
     go version | sed -nE -e 's/[^0-9.]+([0-9.]+).+/\1/p'
 }
@@ -24,11 +22,6 @@ version_lt() {
     fi
 }
 
-if version_lt "$(go_version)" "$go_version_minimum"; then
-    echo "awm-relayer requires Go >= $go_version_minimum, Go $(go_version) found." >&2
-    exit 1
-fi
-
 # Root directory
 RELAYER_PATH=$(
     cd "$(dirname "${BASH_SOURCE[0]}")"
@@ -38,6 +31,13 @@ RELAYER_PATH=$(
 # Load the versions and constants
 source "$RELAYER_PATH"/scripts/versions.sh
 source "$RELAYER_PATH"/scripts/constants.sh
+
+go_version_minimum=$GO_VERSION
+
+if version_lt "$(go_version)" "$go_version_minimum"; then
+    echo "awm-relayer requires Go >= $go_version_minimum, Go $(go_version) found." >&2
+    exit 1
+fi
 
 if [[ $# -eq 1 ]]; then
     binary_path=$1


### PR DESCRIPTION
## Why this should be merged
`GO_VERSION=$GO_VERSION >> $GITHUB_ENV` is not a proper bash command, so was failing, but silently for some reason. This was causing the env var not to be set, so the `go-version` in `actions/setup-go@v5` was defaulting to `1.20.11`

## How this works

## How this was tested

## How is this documented