### PR TITLE
Sync subnet-evm versions in e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ava-labs/subnet-evm
-          ref: v0.5.8 # TODO set with env.SUBNET_EVM_VERSION
+          ref: ${{ env.SUBNET_EVM_VERSION }}
 
       - name: Install AvalancheGo Release
         run: BASEDIR=/tmp/e2e-test AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego ./scripts/install_avalanchego_release.sh


### PR DESCRIPTION
## Why this should be merged
Keeps the e2e tests up-to-date with the version of `subnet-evm` in the `go.mod` file.

## How this works
We use `versions.sh` to get the proper version from `go.mod`.

## How this was tested
E2E tests in CI

## How is this documented
N/A