### PR TITLE
Fetch warp numerator

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -251,7 +251,7 @@ func setQuorumNumerator(cfgNumerator uint64) uint64 {
 // Differentiates between subnet-evm and coreth RPC internally
 func getWarpQuorum(
 	subnetID ids.ID,
-	rpc string,
+	client ethclient.Client,
 ) (WarpQuorum, error) {
 	if subnetID == constants.PrimaryNetworkID {
 		return WarpQuorum{
@@ -260,10 +260,6 @@ func getWarpQuorum(
 		}, nil
 	} else {
 		// Fetch the subnet's chain config
-		client, err := ethclient.Dial(rpc)
-		if err != nil {
-			return WarpQuorum{}, fmt.Errorf("failed to dial subnet %s: %v", subnetID, err)
-		}
 		chainConfig, err := client.ChainConfig(context.Background())
 		if err != nil {
 			return WarpQuorum{}, fmt.Errorf("failed to fetch chain config for subnet %s: %v", subnetID, err)
@@ -279,7 +275,8 @@ func getWarpQuorum(
 		}
 
 		// If we didn't find the Warp config in the genesis precompile list, check the upgrade precompiles
-		for _, precompile := range chainConfig.UpgradeConfig.PrecompileUpgrades {
+		upgrades := chainConfig.ToWithUpgradesJSON().UpgradeConfig.PrecompileUpgrades
+		for _, precompile := range upgrades {
 			warpConfig, ok := precompile.Config.(*warp.Config)
 			if ok {
 				return WarpQuorum{
@@ -302,10 +299,15 @@ func (c *Config) initializeWarpQuorum() error {
 			return fmt.Errorf("invalid subnetID in configuration. error: %v", err)
 		}
 
-		quorum, err := getWarpQuorum(subnetID, sourceSubnet.GetNodeRPCEndpoint())
+		client, err := ethclient.Dial(sourceSubnet.GetNodeRPCEndpoint())
+		if err != nil {
+			return fmt.Errorf("failed to dial source subnet %s: %v", subnetID, err)
+		}
+		quorum, err := getWarpQuorum(subnetID, client)
 		if err != nil {
 			return err
 		}
+
 		c.warpQuorum[subnetID] = quorum
 	}
 
@@ -321,10 +323,15 @@ func (c *Config) initializeWarpQuorum() error {
 			continue
 		}
 
-		quorum, err := getWarpQuorum(subnetID, destinationSubnet.GetNodeRPCEndpoint())
+		client, err := ethclient.Dial(destinationSubnet.GetNodeRPCEndpoint())
+		if err != nil {
+			return fmt.Errorf("failed to dial destination subnet %s: %v", subnetID, err)
+		}
+		quorum, err := getWarpQuorum(subnetID, client)
 		if err != nil {
 			return err
 		}
+
 		c.warpQuorum[subnetID] = quorum
 	}
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -239,6 +239,14 @@ func (c *Config) Validate() error {
 	return nil
 }
 
+// If the numerator in the Warp config is 0, use the default value
+func setQuorumNumerator(cfgNumerator uint64) uint64 {
+	if cfgNumerator == 0 {
+		return params.WarpDefaultQuorumNumerator
+	}
+	return cfgNumerator
+}
+
 // Helper to retrieve the Warp Quorum from the chain config.
 // Differentiates between subnet-evm and coreth RPC internally
 func getWarpQuorum(
@@ -264,12 +272,8 @@ func getWarpQuorum(
 		// First, check if the Warp precompile was enabled at genesis
 		warpConfig, ok := chainConfig.GenesisPrecompiles["warpConfig"].(*warp.Config)
 		if ok {
-			numerator := warpConfig.QuorumNumerator
-			if numerator == 0 {
-				numerator = params.WarpDefaultQuorumNumerator
-			}
 			return WarpQuorum{
-				QuorumNumerator:   numerator,
+				QuorumNumerator:   setQuorumNumerator(warpConfig.QuorumNumerator),
 				QuorumDenominator: params.WarpQuorumDenominator,
 			}, nil
 		}
@@ -278,12 +282,8 @@ func getWarpQuorum(
 		for _, precompile := range chainConfig.UpgradeConfig.PrecompileUpgrades {
 			warpConfig, ok := precompile.Config.(*warp.Config)
 			if ok {
-				numerator := warpConfig.QuorumNumerator
-				if numerator == 0 {
-					numerator = params.WarpDefaultQuorumNumerator
-				}
 				return WarpQuorum{
-					QuorumNumerator:   numerator,
+					QuorumNumerator:   setQuorumNumerator(warpConfig.QuorumNumerator),
 					QuorumDenominator: params.WarpQuorumDenominator,
 				}, nil
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -269,14 +269,24 @@ func getWarpQuorum(
 
 	// First, check the list of precompile upgrades to get the most up to date Warp config
 	upgrades := chainConfig.ToWithUpgradesJSON().UpgradeConfig.PrecompileUpgrades
+	var warpConfig *warp.Config
 	for _, precompile := range upgrades {
-		warpConfig, ok := precompile.Config.(*warp.Config)
+		cfg, ok := precompile.Config.(*warp.Config)
 		if ok {
-			return WarpQuorum{
-				QuorumNumerator:   setQuorumNumerator(warpConfig.QuorumNumerator),
-				QuorumDenominator: params.WarpQuorumDenominator,
-			}, nil
+			if warpConfig == nil {
+				cfg = warpConfig
+				continue
+			}
+			if *cfg.Timestamp() > *warpConfig.Timestamp() {
+				warpConfig = cfg
+			}
 		}
+	}
+	if warpConfig != nil {
+		return WarpQuorum{
+			QuorumNumerator:   setQuorumNumerator(warpConfig.QuorumNumerator),
+			QuorumDenominator: params.WarpQuorumDenominator,
+		}, nil
 	}
 
 	// If we didn't find the Warp config in the upgrade precompile list, check the genesis config

--- a/config/config.go
+++ b/config/config.go
@@ -276,7 +276,7 @@ func getWarpQuorum(
 		cfg, ok := precompile.Config.(*warp.Config)
 		if ok {
 			if warpConfig == nil {
-				cfg = warpConfig
+				warpConfig = cfg
 				continue
 			}
 			if *cfg.Timestamp() > *warpConfig.Timestamp() {

--- a/config/config.go
+++ b/config/config.go
@@ -250,6 +250,7 @@ func setQuorumNumerator(cfgNumerator uint64) uint64 {
 // Helper to retrieve the Warp Quorum from the chain config.
 // Differentiates between subnet-evm and coreth RPC internally
 func getWarpQuorum(
+	blockchainID ids.ID,
 	subnetID ids.ID,
 	client ethclient.Client,
 ) (WarpQuorum, error) {
@@ -263,7 +264,7 @@ func getWarpQuorum(
 	// Fetch the subnet's chain config
 	chainConfig, err := client.ChainConfig(context.Background())
 	if err != nil {
-		return WarpQuorum{}, fmt.Errorf("failed to fetch chain config for subnet %s: %v", subnetID, err)
+		return WarpQuorum{}, fmt.Errorf("failed to fetch chain config for blockchain %s: %v", blockchainID, err)
 	}
 
 	// First, check the list of precompile upgrades to get the most up to date Warp config
@@ -286,7 +287,7 @@ func getWarpQuorum(
 			QuorumDenominator: params.WarpQuorumDenominator,
 		}, nil
 	}
-	return WarpQuorum{}, fmt.Errorf("failed to find warp config for subnet %s", subnetID)
+	return WarpQuorum{}, fmt.Errorf("failed to find warp config for blockchain %s", blockchainID)
 }
 
 func (c *Config) initializeWarpQuorum() error {
@@ -294,6 +295,10 @@ func (c *Config) initializeWarpQuorum() error {
 
 	// Fetch the Warp quorum values for each source subnet
 	for _, sourceSubnet := range c.SourceSubnets {
+		blockchainID, err := ids.FromString(sourceSubnet.BlockchainID)
+		if err != nil {
+			return fmt.Errorf("invalid blockchainID in configuration. error: %v", err)
+		}
 		subnetID, err := ids.FromString(sourceSubnet.SubnetID)
 		if err != nil {
 			return fmt.Errorf("invalid subnetID in configuration. error: %v", err)
@@ -304,37 +309,41 @@ func (c *Config) initializeWarpQuorum() error {
 			return fmt.Errorf("failed to dial source subnet %s: %v", subnetID, err)
 		}
 		defer client.Close()
-		quorum, err := getWarpQuorum(subnetID, client)
+		quorum, err := getWarpQuorum(blockchainID, subnetID, client)
 		if err != nil {
 			return err
 		}
 
-		c.warpQuorum[subnetID] = quorum
+		c.warpQuorum[blockchainID] = quorum
 	}
 
 	// Fetch the Warp quorum values for each destination subnet.
 	// We do this to properly handle Warp messages originating from the primary network
 	for _, destinationSubnet := range c.DestinationSubnets {
+		blockchainID, err := ids.FromString(destinationSubnet.BlockchainID)
+		if err != nil {
+			return fmt.Errorf("invalid blockchainID in configuration. error: %v", err)
+		}
 		subnetID, err := ids.FromString(destinationSubnet.SubnetID)
 		if err != nil {
 			return fmt.Errorf("invalid subnetID in configuration. error: %v", err)
 		}
-		if _, ok := c.warpQuorum[subnetID]; ok {
+		if _, ok := c.warpQuorum[blockchainID]; ok {
 			// We already fetched the quorum for this subnet
 			continue
 		}
 
 		client, err := ethclient.Dial(destinationSubnet.GetNodeRPCEndpoint())
 		if err != nil {
-			return fmt.Errorf("failed to dial destination subnet %s: %v", subnetID, err)
+			return fmt.Errorf("failed to dial destination blockchain %s: %v", blockchainID, err)
 		}
 		defer client.Close()
-		quorum, err := getWarpQuorum(subnetID, client)
+		quorum, err := getWarpQuorum(blockchainID, subnetID, client)
 		if err != nil {
 			return err
 		}
 
-		c.warpQuorum[subnetID] = quorum
+		c.warpQuorum[blockchainID] = quorum
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -258,35 +258,35 @@ func getWarpQuorum(
 			QuorumNumerator:   params.WarpDefaultQuorumNumerator,
 			QuorumDenominator: params.WarpQuorumDenominator,
 		}, nil
-	} else {
-		// Fetch the subnet's chain config
-		chainConfig, err := client.ChainConfig(context.Background())
-		if err != nil {
-			return WarpQuorum{}, fmt.Errorf("failed to fetch chain config for subnet %s: %v", subnetID, err)
-		}
+	}
 
-		// First, check if the Warp precompile was enabled at genesis
-		warpConfig, ok := chainConfig.GenesisPrecompiles["warpConfig"].(*warp.Config)
+	// Fetch the subnet's chain config
+	chainConfig, err := client.ChainConfig(context.Background())
+	if err != nil {
+		return WarpQuorum{}, fmt.Errorf("failed to fetch chain config for subnet %s: %v", subnetID, err)
+	}
+
+	// First, check the list of precompile upgrades to get the most up to date Warp config
+	upgrades := chainConfig.ToWithUpgradesJSON().UpgradeConfig.PrecompileUpgrades
+	for _, precompile := range upgrades {
+		warpConfig, ok := precompile.Config.(*warp.Config)
 		if ok {
 			return WarpQuorum{
 				QuorumNumerator:   setQuorumNumerator(warpConfig.QuorumNumerator),
 				QuorumDenominator: params.WarpQuorumDenominator,
 			}, nil
 		}
-
-		// If we didn't find the Warp config in the genesis precompile list, check the upgrade precompiles
-		upgrades := chainConfig.ToWithUpgradesJSON().UpgradeConfig.PrecompileUpgrades
-		for _, precompile := range upgrades {
-			warpConfig, ok := precompile.Config.(*warp.Config)
-			if ok {
-				return WarpQuorum{
-					QuorumNumerator:   setQuorumNumerator(warpConfig.QuorumNumerator),
-					QuorumDenominator: params.WarpQuorumDenominator,
-				}, nil
-			}
-		}
-		return WarpQuorum{}, fmt.Errorf("failed to find warp config for subnet %s", subnetID)
 	}
+
+	// If we didn't find the Warp config in the upgrade precompile list, check the genesis config
+	warpConfig, ok := chainConfig.GenesisPrecompiles["warpConfig"].(*warp.Config)
+	if ok {
+		return WarpQuorum{
+			QuorumNumerator:   setQuorumNumerator(warpConfig.QuorumNumerator),
+			QuorumDenominator: params.WarpQuorumDenominator,
+		}, nil
+	}
+	return WarpQuorum{}, fmt.Errorf("failed to find warp config for subnet %s", subnetID)
 }
 
 func (c *Config) initializeWarpQuorum() error {
@@ -303,6 +303,7 @@ func (c *Config) initializeWarpQuorum() error {
 		if err != nil {
 			return fmt.Errorf("failed to dial source subnet %s: %v", subnetID, err)
 		}
+		defer client.Close()
 		quorum, err := getWarpQuorum(subnetID, client)
 		if err != nil {
 			return err
@@ -327,6 +328,7 @@ func (c *Config) initializeWarpQuorum() error {
 		if err != nil {
 			return fmt.Errorf("failed to dial destination subnet %s: %v", subnetID, err)
 		}
+		defer client.Close()
 		quorum, err := getWarpQuorum(subnetID, client)
 		if err != nil {
 			return err

--- a/config/config.go
+++ b/config/config.go
@@ -18,8 +18,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/awm-relayer/utils"
-	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/subnet-evm/ethclient"
+	"github.com/ava-labs/subnet-evm/params"
 	"github.com/ava-labs/subnet-evm/x/warp"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -251,6 +251,7 @@ func getWarpQuorum(
 			QuorumDenominator: params.WarpQuorumDenominator,
 		}, nil
 	} else {
+		// Fetch the subnet's chain config
 		client, err := ethclient.Dial(rpc)
 		if err != nil {
 			return WarpQuorum{}, fmt.Errorf("failed to dial subnet %s: %v", subnetID, err)
@@ -259,19 +260,35 @@ func getWarpQuorum(
 		if err != nil {
 			return WarpQuorum{}, fmt.Errorf("failed to fetch chain config for subnet %s: %v", subnetID, err)
 		}
+
+		// First, check if the Warp precompile was enabled at genesis
 		warpConfig, ok := chainConfig.GenesisPrecompiles["warpConfig"].(*warp.Config)
-		if !ok {
-			return WarpQuorum{}, fmt.Errorf("failed to parse warpConfig for subnet %s", subnetID)
+		if ok {
+			numerator := warpConfig.QuorumNumerator
+			if numerator == 0 {
+				numerator = params.WarpDefaultQuorumNumerator
+			}
+			return WarpQuorum{
+				QuorumNumerator:   numerator,
+				QuorumDenominator: params.WarpQuorumDenominator,
+			}, nil
 		}
 
-		numerator := warpConfig.QuorumNumerator
-		if numerator == 0 {
-			numerator = params.WarpDefaultQuorumNumerator
+		// If we didn't find the Warp config in the genesis precompile list, check the upgrade precompiles
+		for _, precompile := range chainConfig.UpgradeConfig.PrecompileUpgrades {
+			warpConfig, ok := precompile.Config.(*warp.Config)
+			if ok {
+				numerator := warpConfig.QuorumNumerator
+				if numerator == 0 {
+					numerator = params.WarpDefaultQuorumNumerator
+				}
+				return WarpQuorum{
+					QuorumNumerator:   numerator,
+					QuorumDenominator: params.WarpQuorumDenominator,
+				}, nil
+			}
 		}
-		return WarpQuorum{
-			QuorumNumerator:   numerator,
-			QuorumDenominator: params.WarpQuorumDenominator,
-		}, nil
+		return WarpQuorum{}, fmt.Errorf("failed to find warp config for subnet %s", subnetID)
 	}
 }
 
@@ -298,6 +315,10 @@ func (c *Config) initializeWarpQuorum() error {
 		subnetID, err := ids.FromString(destinationSubnet.SubnetID)
 		if err != nil {
 			return fmt.Errorf("invalid subnetID in configuration. error: %v", err)
+		}
+		if _, ok := c.warpQuorum[subnetID]; ok {
+			// We already fetched the quorum for this subnet
+			continue
 		}
 
 		quorum, err := getWarpQuorum(subnetID, destinationSubnet.GetNodeRPCEndpoint())

--- a/config/config.go
+++ b/config/config.go
@@ -268,9 +268,8 @@ func getWarpQuorum(
 	}
 
 	// First, check the list of precompile upgrades to get the most up to date Warp config
-	upgrades := chainConfig.ToWithUpgradesJSON().UpgradeConfig.PrecompileUpgrades
 	var warpConfig *warp.Config
-	for _, precompile := range upgrades {
+	for _, precompile := range chainConfig.UpgradeConfig.PrecompileUpgrades {
 		cfg, ok := precompile.Config.(*warp.Config)
 		if ok {
 			if warpConfig == nil {

--- a/config/config.go
+++ b/config/config.go
@@ -268,6 +268,9 @@ func getWarpQuorum(
 	}
 
 	// First, check the list of precompile upgrades to get the most up to date Warp config
+	// We only need to consider the most recent Warp config, since the QuorumNumerator is used
+	// at signature verification time on the receiving chain, regardless of the Warp config at the
+	// time of the message's creation
 	var warpConfig *warp.Config
 	for _, precompile := range chainConfig.UpgradeConfig.PrecompileUpgrades {
 		cfg, ok := precompile.Config.(*warp.Config)

--- a/config/config.go
+++ b/config/config.go
@@ -18,9 +18,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/awm-relayer/utils"
-	corethClient "github.com/ava-labs/coreth/ethclient"
 	"github.com/ava-labs/coreth/params"
-	corethWarp "github.com/ava-labs/coreth/precompile/contracts/warp"
 	"github.com/ava-labs/subnet-evm/ethclient"
 	"github.com/ava-labs/subnet-evm/x/warp"
 	"github.com/ethereum/go-ethereum/common"
@@ -248,30 +246,10 @@ func getWarpQuorum(
 	rpc string,
 ) (WarpQuorum, error) {
 	if subnetID == constants.PrimaryNetworkID {
-		client, err := corethClient.Dial(rpc)
-		if err != nil {
-			return WarpQuorum{}, fmt.Errorf("failed to dial primary network: %v", err)
-		}
-		chainConfig, err := client.ChainConfig(context.Background())
-		if err != nil {
-			return WarpQuorum{}, fmt.Errorf("failed to fetch chain config for primary network: %v", err)
-		}
-		precompiles := chainConfig.PrecompileUpgrades
-		for _, precompile := range precompiles {
-			warpConfig, ok := precompile.Config.(*corethWarp.Config)
-			if ok {
-				numerator := warpConfig.QuorumNumerator
-				if numerator == 0 {
-					numerator = params.WarpDefaultQuorumNumerator
-				}
-				return WarpQuorum{
-					QuorumNumerator:   numerator,
-					QuorumDenominator: params.WarpQuorumDenominator,
-				}, nil
-			}
-		}
-		return WarpQuorum{}, fmt.Errorf("failed to find warpConfig for primary network")
-
+		return WarpQuorum{
+			QuorumNumerator:   params.WarpDefaultQuorumNumerator,
+			QuorumDenominator: params.WarpQuorumDenominator,
+		}, nil
 	} else {
 		client, err := ethclient.Dial(rpc)
 		if err != nil {
@@ -306,10 +284,6 @@ func (c *Config) initializeWarpQuorum() error {
 		if err != nil {
 			return fmt.Errorf("invalid subnetID in configuration. error: %v", err)
 		}
-		// TODO: Figure out how to retrieve the warp config from the C-Chain
-		if subnetID == constants.PrimaryNetworkID {
-			continue
-		}
 
 		quorum, err := getWarpQuorum(subnetID, sourceSubnet.GetNodeRPCEndpoint())
 		if err != nil {
@@ -324,10 +298,6 @@ func (c *Config) initializeWarpQuorum() error {
 		subnetID, err := ids.FromString(destinationSubnet.SubnetID)
 		if err != nil {
 			return fmt.Errorf("invalid subnetID in configuration. error: %v", err)
-		}
-		// TODO: Figure out how to retrieve the warp config from the C-Chain
-		if subnetID == constants.PrimaryNetworkID {
-			continue
 		}
 
 		quorum, err := getWarpQuorum(subnetID, destinationSubnet.GetNodeRPCEndpoint())

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
 	"errors"
@@ -17,6 +18,11 @@ import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/awm-relayer/utils"
+	corethClient "github.com/ava-labs/coreth/ethclient"
+	"github.com/ava-labs/coreth/params"
+	corethWarp "github.com/ava-labs/coreth/precompile/contracts/warp"
+	"github.com/ava-labs/subnet-evm/ethclient"
+	"github.com/ava-labs/subnet-evm/x/warp"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/spf13/viper"
@@ -63,6 +69,11 @@ type DestinationSubnet struct {
 	AccountPrivateKey string `mapstructure:"account-private-key" json:"account-private-key"`
 }
 
+type WarpQuorum struct {
+	QuorumNumerator   uint64
+	QuorumDenominator uint64
+}
+
 type Config struct {
 	LogLevel            string              `mapstructure:"log-level" json:"log-level"`
 	NetworkID           uint32              `mapstructure:"network-id" json:"network-id"`
@@ -76,6 +87,9 @@ type Config struct {
 	// convenience fields to access the source subnet and chain IDs after initialization
 	sourceSubnetIDs     []ids.ID
 	sourceBlockchainIDs []ids.ID
+
+	// convenience field to store the Warp quorum figures for each subnet
+	warpQuorum map[ids.ID]WarpQuorum
 }
 
 func SetDefaultConfigValues(v *viper.Viper) {
@@ -162,6 +176,10 @@ func BuildConfig(v *viper.Viper) (Config, bool, error) {
 	}
 	cfg.PChainAPIURL = pChainapiUrl
 
+	if err = cfg.initializeWarpQuorum(); err != nil {
+		return Config{}, false, err
+	}
+
 	return cfg, optionOverwritten, nil
 }
 
@@ -220,6 +238,104 @@ func (c *Config) Validate() error {
 	c.sourceSubnetIDs = sourceSubnetIDs
 	c.sourceBlockchainIDs = sourceBlockchainIDs
 
+	return nil
+}
+
+// Helper to retrieve the Warp Quorum from the chain config.
+// Differentiates between subnet-evm and coreth RPC internally
+func getWarpQuorum(
+	subnetID ids.ID,
+	rpc string,
+) (WarpQuorum, error) {
+	if subnetID == constants.PrimaryNetworkID {
+		client, err := corethClient.Dial(rpc)
+		if err != nil {
+			return WarpQuorum{}, fmt.Errorf("failed to dial primary network: %v", err)
+		}
+		chainConfig, err := client.ChainConfig(context.Background())
+		if err != nil {
+			return WarpQuorum{}, fmt.Errorf("failed to fetch chain config for primary network: %v", err)
+		}
+		precompiles := chainConfig.PrecompileUpgrades
+		for _, precompile := range precompiles {
+			warpConfig, ok := precompile.Config.(*corethWarp.Config)
+			if ok {
+				numerator := warpConfig.QuorumNumerator
+				if numerator == 0 {
+					numerator = params.WarpDefaultQuorumNumerator
+				}
+				return WarpQuorum{
+					QuorumNumerator:   numerator,
+					QuorumDenominator: params.WarpQuorumDenominator,
+				}, nil
+			}
+		}
+		return WarpQuorum{}, fmt.Errorf("failed to find warpConfig for primary network")
+
+	} else {
+		client, err := ethclient.Dial(rpc)
+		if err != nil {
+			return WarpQuorum{}, fmt.Errorf("failed to dial subnet %s: %v", subnetID, err)
+		}
+		chainConfig, err := client.ChainConfig(context.Background())
+		if err != nil {
+			return WarpQuorum{}, fmt.Errorf("failed to fetch chain config for subnet %s: %v", subnetID, err)
+		}
+		warpConfig, ok := chainConfig.GenesisPrecompiles["warpConfig"].(*warp.Config)
+		if !ok {
+			return WarpQuorum{}, fmt.Errorf("failed to parse warpConfig for subnet %s", subnetID)
+		}
+
+		numerator := warpConfig.QuorumNumerator
+		if numerator == 0 {
+			numerator = params.WarpDefaultQuorumNumerator
+		}
+		return WarpQuorum{
+			QuorumNumerator:   numerator,
+			QuorumDenominator: params.WarpQuorumDenominator,
+		}, nil
+	}
+}
+
+func (c *Config) initializeWarpQuorum() error {
+	c.warpQuorum = make(map[ids.ID]WarpQuorum)
+
+	// Fetch the Warp quorum values for each source subnet
+	for _, sourceSubnet := range c.SourceSubnets {
+		subnetID, err := ids.FromString(sourceSubnet.SubnetID)
+		if err != nil {
+			return fmt.Errorf("invalid subnetID in configuration. error: %v", err)
+		}
+		// TODO: Figure out how to retrieve the warp config from the C-Chain
+		if subnetID == constants.PrimaryNetworkID {
+			continue
+		}
+
+		quorum, err := getWarpQuorum(subnetID, sourceSubnet.GetNodeRPCEndpoint())
+		if err != nil {
+			return err
+		}
+		c.warpQuorum[subnetID] = quorum
+	}
+
+	// Fetch the Warp quorum values for each destination subnet.
+	// We do this to properly handle Warp messages originating from the primary network
+	for _, destinationSubnet := range c.DestinationSubnets {
+		subnetID, err := ids.FromString(destinationSubnet.SubnetID)
+		if err != nil {
+			return fmt.Errorf("invalid subnetID in configuration. error: %v", err)
+		}
+		// TODO: Figure out how to retrieve the warp config from the C-Chain
+		if subnetID == constants.PrimaryNetworkID {
+			continue
+		}
+
+		quorum, err := getWarpQuorum(subnetID, destinationSubnet.GetNodeRPCEndpoint())
+		if err != nil {
+			return err
+		}
+		c.warpQuorum[subnetID] = quorum
+	}
 	return nil
 }
 
@@ -414,4 +530,8 @@ func (s *DestinationSubnet) GetRelayerAccountInfo() (*ecdsa.PrivateKey, common.A
 // GetSourceIDs returns the Subnet and Chain IDs of all subnets configured as a source
 func (c *Config) GetSourceIDs() ([]ids.ID, []ids.ID) {
 	return c.sourceSubnetIDs, c.sourceBlockchainIDs
+}
+
+func (c *Config) GetWarpQuorum() map[ids.ID]WarpQuorum {
+	return c.warpQuorum
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -420,6 +420,7 @@ func TestGetWarpQuorum(t *testing.T) {
 	blockchainID, err := ids.FromString("p433wpuXyJiDhyazPYyZMJeaoPSW76CBZ2x7wrVPLgvokotXz")
 	require.NoError(t, err)
 	subnetID, err := ids.FromString("2PsShLjrFFwR51DMcAh8pyuwzLn1Ym3zRhuXLTmLCR1STk2mL6")
+	require.NoError(t, err)
 
 	testCases := []struct {
 		name                string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,9 +12,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/awm-relayer/utils"
+	mock_ethclient "github.com/ava-labs/awm-relayer/vms/evm/mocks"
+	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/x/warp"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 var (
@@ -409,4 +414,118 @@ func TestGetRelayerAccountInfoSkipChainConfigCheckCompatible(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, expectedAddress, address.String())
+}
+
+func TestGetWarpQuorum(t *testing.T) {
+	subnetID, err := ids.FromString("p433wpuXyJiDhyazPYyZMJeaoPSW76CBZ2x7wrVPLgvokotXz")
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name                string
+		subnetID            ids.ID
+		chainConfig         params.ChainConfig
+		getChainConfigCalls int
+		expectedError       error
+		expectedQuorum      WarpQuorum
+	}{
+		{
+			name:                "primary network",
+			subnetID:            ids.Empty,
+			getChainConfigCalls: 0,
+			expectedError:       nil,
+			expectedQuorum: WarpQuorum{
+				QuorumNumerator:   params.WarpDefaultQuorumNumerator,
+				QuorumDenominator: params.WarpQuorumDenominator,
+			},
+		},
+		{
+			name:                "subnet genesis precompile",
+			subnetID:            subnetID,
+			getChainConfigCalls: 1,
+			chainConfig: params.ChainConfig{
+				GenesisPrecompiles: params.Precompiles{
+					"warpConfig": &warp.Config{
+						QuorumNumerator: 0,
+					},
+				},
+			},
+			expectedError: nil,
+			expectedQuorum: WarpQuorum{
+				QuorumNumerator:   params.WarpDefaultQuorumNumerator,
+				QuorumDenominator: params.WarpQuorumDenominator,
+			},
+		},
+		{
+			name:                "subnet genesis precompile non-default",
+			subnetID:            subnetID,
+			getChainConfigCalls: 1,
+			chainConfig: params.ChainConfig{
+				GenesisPrecompiles: params.Precompiles{
+					"warpConfig": &warp.Config{
+						QuorumNumerator: 50,
+					},
+				},
+			},
+			expectedError: nil,
+			expectedQuorum: WarpQuorum{
+				QuorumNumerator:   50,
+				QuorumDenominator: params.WarpQuorumDenominator,
+			},
+		},
+		{
+			name:                "subnet upgrade precompile",
+			subnetID:            subnetID,
+			getChainConfigCalls: 1,
+			chainConfig: params.ChainConfig{
+				UpgradeConfig: params.UpgradeConfig{
+					PrecompileUpgrades: []params.PrecompileUpgrade{
+						{
+							Config: &warp.Config{
+								QuorumNumerator: 0,
+							},
+						},
+					},
+				},
+			},
+			expectedError: nil,
+			expectedQuorum: WarpQuorum{
+				QuorumNumerator:   params.WarpDefaultQuorumNumerator,
+				QuorumDenominator: params.WarpQuorumDenominator,
+			},
+		},
+		{
+			name:                "subnet upgrade precompile non-default",
+			subnetID:            subnetID,
+			getChainConfigCalls: 1,
+			chainConfig: params.ChainConfig{
+				UpgradeConfig: params.UpgradeConfig{
+					PrecompileUpgrades: []params.PrecompileUpgrade{
+						{
+							Config: &warp.Config{
+								QuorumNumerator: 50,
+							},
+						},
+					},
+				},
+			},
+			expectedError: nil,
+			expectedQuorum: WarpQuorum{
+				QuorumNumerator:   50,
+				QuorumDenominator: params.WarpQuorumDenominator,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			client := mock_ethclient.NewMockClient(gomock.NewController(t))
+			gomock.InOrder(
+				client.EXPECT().ChainConfig(gomock.Any()).Return(&testCase.chainConfig, nil).Times(testCase.getChainConfigCalls),
+			)
+
+			quorum, err := getWarpQuorum(testCase.subnetID, client)
+			require.Equal(t, testCase.expectedError, err)
+			require.Equal(t, testCase.expectedQuorum, quorum)
+		})
+	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -417,11 +417,13 @@ func TestGetRelayerAccountInfoSkipChainConfigCheckCompatible(t *testing.T) {
 }
 
 func TestGetWarpQuorum(t *testing.T) {
-	subnetID, err := ids.FromString("p433wpuXyJiDhyazPYyZMJeaoPSW76CBZ2x7wrVPLgvokotXz")
+	blockchainID, err := ids.FromString("p433wpuXyJiDhyazPYyZMJeaoPSW76CBZ2x7wrVPLgvokotXz")
 	require.NoError(t, err)
+	subnetID, err := ids.FromString("2PsShLjrFFwR51DMcAh8pyuwzLn1Ym3zRhuXLTmLCR1STk2mL6")
 
 	testCases := []struct {
 		name                string
+		blockchainID        ids.ID
 		subnetID            ids.ID
 		chainConfig         params.ChainConfig
 		getChainConfigCalls int
@@ -430,6 +432,7 @@ func TestGetWarpQuorum(t *testing.T) {
 	}{
 		{
 			name:                "primary network",
+			blockchainID:        blockchainID,
 			subnetID:            ids.Empty,
 			getChainConfigCalls: 0,
 			expectedError:       nil,
@@ -440,6 +443,7 @@ func TestGetWarpQuorum(t *testing.T) {
 		},
 		{
 			name:                "subnet genesis precompile",
+			blockchainID:        blockchainID,
 			subnetID:            subnetID,
 			getChainConfigCalls: 1,
 			chainConfig: params.ChainConfig{
@@ -457,6 +461,7 @@ func TestGetWarpQuorum(t *testing.T) {
 		},
 		{
 			name:                "subnet genesis precompile non-default",
+			blockchainID:        blockchainID,
 			subnetID:            subnetID,
 			getChainConfigCalls: 1,
 			chainConfig: params.ChainConfig{
@@ -474,6 +479,7 @@ func TestGetWarpQuorum(t *testing.T) {
 		},
 		{
 			name:                "subnet upgrade precompile",
+			blockchainID:        blockchainID,
 			subnetID:            subnetID,
 			getChainConfigCalls: 1,
 			chainConfig: params.ChainConfig{
@@ -495,6 +501,7 @@ func TestGetWarpQuorum(t *testing.T) {
 		},
 		{
 			name:                "subnet upgrade precompile non-default",
+			blockchainID:        blockchainID,
 			subnetID:            subnetID,
 			getChainConfigCalls: 1,
 			chainConfig: params.ChainConfig{
@@ -523,7 +530,7 @@ func TestGetWarpQuorum(t *testing.T) {
 				client.EXPECT().ChainConfig(gomock.Any()).Return(&testCase.chainConfig, nil).Times(testCase.getChainConfigCalls),
 			)
 
-			quorum, err := getWarpQuorum(testCase.subnetID, client)
+			quorum, err := getWarpQuorum(testCase.blockchainID, testCase.subnetID, client)
 			require.Equal(t, testCase.expectedError, err)
 			require.Equal(t, testCase.expectedQuorum, quorum)
 		})

--- a/main/main.go
+++ b/main/main.go
@@ -207,13 +207,6 @@ func runRelayer(logger logging.Logger,
 		zap.String("blockchainID", sourceSubnetInfo.BlockchainID),
 	)
 
-	subnetID, err := ids.FromString(sourceSubnetInfo.SubnetID)
-	if err != nil {
-		// The subnetID should have already been validated
-		panic(err)
-	}
-	quorum := cfg.GetWarpQuorum()[subnetID]
-
 	relayer, subscriber, err := relayer.NewRelayer(
 		logger,
 		db,
@@ -223,7 +216,6 @@ func runRelayer(logger logging.Logger,
 		responseChan,
 		destinationClients,
 		cfg.ProcessMissedBlocks,
-		quorum,
 	)
 	if err != nil {
 		logger.Error(
@@ -249,7 +241,7 @@ func runRelayer(logger logging.Logger,
 			)
 
 			// Relay the message to the destination chain. Continue on failure.
-			err = relayer.RelayMessage(&txLog, metrics, messageCreator)
+			err = relayer.RelayMessage(&txLog, metrics, messageCreator, &cfg)
 			if err != nil {
 				logger.Error(
 					"Error relaying message",

--- a/main/main.go
+++ b/main/main.go
@@ -85,7 +85,7 @@ func main() {
 	}
 
 	// Initialize metrics gathered through prometheus
-	gatherer, registerer, err := initMetrics()
+	gatherer, registerer, err := initializeMetrics()
 	if err != nil {
 		logger.Fatal("failed to set up prometheus metrics",
 			zap.Error(err))
@@ -279,7 +279,7 @@ func startMetricsServer(logger logging.Logger, gatherer prometheus.Gatherer, por
 	}()
 }
 
-func initMetrics() (prometheus.Gatherer, prometheus.Registerer, error) {
+func initializeMetrics() (prometheus.Gatherer, prometheus.Registerer, error) {
 	gatherer := metrics.NewMultiGatherer()
 	registry := prometheus.NewRegistry()
 	if err := gatherer.Register("app", registry); err != nil {

--- a/main/main.go
+++ b/main/main.go
@@ -84,18 +84,17 @@ func main() {
 		return
 	}
 
-	// Initialize the global app request network
-	logger.Info("Initializing app request network")
-	sourceSubnetIDs, sourceBlockchainIDs := cfg.GetSourceIDs()
-
 	// Initialize metrics gathered through prometheus
 	gatherer, registerer, err := initMetrics()
 	if err != nil {
 		logger.Fatal("failed to set up prometheus metrics",
 			zap.Error(err))
-		panic(err)
+		return
 	}
 
+	// Initialize the global app request network
+	logger.Info("Initializing app request network")
+	sourceSubnetIDs, sourceBlockchainIDs := cfg.GetSourceIDs()
 	network, responseChans, err := peers.NewNetwork(logger, registerer, cfg.NetworkID, sourceSubnetIDs, sourceBlockchainIDs, cfg.PChainAPIURL)
 	if err != nil {
 		logger.Error(
@@ -276,13 +275,7 @@ func startMetricsServer(logger logging.Logger, gatherer prometheus.Gatherer, por
 	go func() {
 		logger.Info("starting metrics server...",
 			zap.Uint32("port", port))
-		err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
-		if err != nil {
-			logger.Fatal("metrics server exited",
-				zap.Error(err),
-				zap.Uint32("port", port))
-			panic(err)
-		}
+		log.Fatalln(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
 	}()
 }
 

--- a/relayer/message_relayer.go
+++ b/relayer/message_relayer.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ava-labs/awm-relayer/peers"
 	"github.com/ava-labs/awm-relayer/utils"
 	"github.com/ava-labs/awm-relayer/vms/vmtypes"
-	"github.com/ava-labs/coreth/params"
 	coreEthMsg "github.com/ava-labs/coreth/plugin/evm/message"
 	msg "github.com/ava-labs/subnet-evm/plugin/evm/message"
 	warpBackend "github.com/ava-labs/subnet-evm/warp"
@@ -183,7 +182,7 @@ func (r *messageRelayer) createSignedMessage() (*warp.Message, error) {
 		signedWarpMessageBytes, err = warpClient.GetMessageAggregateSignature(
 			context.Background(),
 			r.warpMessage.ID(),
-			params.WarpDefaultQuorumNumerator,
+			r.relayer.warpQuorum.QuorumNumerator,
 			signingSubnetID.String(),
 		)
 		if err == nil {
@@ -411,7 +410,12 @@ func (r *messageRelayer) createSignedMessageAppRequest(requestID uint32) (*warp.
 					}
 
 					// As soon as the signatures exceed the stake weight threshold we try to aggregate and send the transaction.
-					if utils.CheckStakeWeightExceedsThreshold(accumulatedSignatureWeight, totalValidatorWeight, params.WarpDefaultQuorumNumerator, params.WarpQuorumDenominator) {
+					if utils.CheckStakeWeightExceedsThreshold(
+						accumulatedSignatureWeight,
+						totalValidatorWeight,
+						r.relayer.warpQuorum.QuorumNumerator,
+						r.relayer.warpQuorum.QuorumDenominator,
+					) {
 						aggSig, vdrBitSet, err := r.aggregateSignatures(signatureMap)
 						if err != nil {
 							r.logger.Error(

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -41,6 +41,7 @@ type Relayer struct {
 	db                       database.RelayerDatabase
 	supportedDestinations    set.Set[ids.ID]
 	apiNodeURI               string
+	warpQuorum               config.WarpQuorum
 }
 
 func NewRelayer(
@@ -52,6 +53,7 @@ func NewRelayer(
 	responseChan chan message.InboundMessage,
 	destinationClients map[ids.ID]vms.DestinationClient,
 	shouldProcessMissedBlocks bool,
+	warpQuorum config.WarpQuorum,
 ) (*Relayer, vms.Subscriber, error) {
 	sub := vms.NewSubscriber(logger, sourceSubnetInfo, db)
 
@@ -122,6 +124,7 @@ func NewRelayer(
 		db:                       db,
 		supportedDestinations:    supportedDestinationsBlockchainIDs,
 		apiNodeURI:               uri,
+		warpQuorum:               warpQuorum,
 	}
 
 	// Open the subscription. We must do this before processing any missed messages, otherwise we may miss an incoming message

--- a/vms/evm/mocks/mock_eth_client.go
+++ b/vms/evm/mocks/mock_eth_client.go
@@ -16,6 +16,7 @@ import (
 	ids "github.com/ava-labs/avalanchego/ids"
 	types "github.com/ava-labs/subnet-evm/core/types"
 	interfaces "github.com/ava-labs/subnet-evm/interfaces"
+	params "github.com/ava-labs/subnet-evm/params"
 	rpc "github.com/ava-labs/subnet-evm/rpc"
 	common "github.com/ethereum/go-ethereum/common"
 	gomock "go.uber.org/mock/gomock"
@@ -192,6 +193,21 @@ func (m *MockClient) CallContractAtHash(ctx context.Context, msg interfaces.Call
 func (mr *MockClientMockRecorder) CallContractAtHash(ctx, msg, blockHash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CallContractAtHash", reflect.TypeOf((*MockClient)(nil).CallContractAtHash), ctx, msg, blockHash)
+}
+
+// ChainConfig mocks base method.
+func (m *MockClient) ChainConfig(arg0 context.Context) (*params.ChainConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChainConfig", arg0)
+	ret0, _ := ret[0].(*params.ChainConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ChainConfig indicates an expected call of ChainConfig.
+func (mr *MockClientMockRecorder) ChainConfig(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainConfig", reflect.TypeOf((*MockClient)(nil).ChainConfig), arg0)
 }
 
 // ChainID mocks base method.


### PR DESCRIPTION
## Why this should be merged
Fixes https://github.com/ava-labs/awm-relayer/issues/8

## How this works
Fetches the Warp Quorum from the Warp Config on startup. Hardcodes the quorum value for the primary network, since that will never change.
Depends on https://github.com/ava-labs/subnet-evm/pull/1040; CI will not pass until that is merged.

## How this was tested
Added unit tests

## How is this documented
N/A