### PR TITLE
Use common.Address instead of common.Hash

### DIFF
--- a/messages/message_manager.go
+++ b/messages/message_manager.go
@@ -35,14 +35,15 @@ type MessageManager interface {
 // Note that DestinationClients may be invoked concurrently by many MessageManagers, so it is assumed that they are implemented in a thread-safe way
 func NewMessageManager(
 	logger logging.Logger,
-	messageProtocolAddress common.Hash,
+	messageProtocolAddress common.Address,
 	messageProtocolConfig config.MessageProtocolConfig,
 	destinationClients map[ids.ID]vms.DestinationClient,
 ) (MessageManager, error) {
 	format := messageProtocolConfig.MessageFormat
 	switch config.ParseMessageProtocol(format) {
 	case config.TELEPORTER:
-		return teleporter.NewMessageManager(logger,
+		return teleporter.NewMessageManager(
+			logger,
 			messageProtocolAddress,
 			messageProtocolConfig,
 			destinationClients,

--- a/messages/teleporter/message_manager.go
+++ b/messages/teleporter/message_manager.go
@@ -29,7 +29,7 @@ const (
 
 type messageManager struct {
 	messageConfig   Config
-	protocolAddress common.Hash
+	protocolAddress common.Address
 
 	// We parse teleporter messages in ShouldSendMessage, cache them to be reused in SendMessage
 	// The cache is keyed by the Warp message ID, NOT the Teleporter message ID
@@ -41,7 +41,7 @@ type messageManager struct {
 
 func NewMessageManager(
 	logger logging.Logger,
-	messageProtocolAddress common.Hash,
+	messageProtocolAddress common.Address,
 	messageProtocolConfig config.MessageProtocolConfig,
 	destinationClients map[ids.ID]vms.DestinationClient,
 ) (*messageManager, error) {
@@ -284,7 +284,7 @@ func (m *messageManager) getTeleporterMessenger(destinationClient vms.Destinatio
 	}
 
 	// Get the teleporter messenger contract
-	teleporterMessenger, err := teleportermessenger.NewTeleporterMessenger(common.BytesToAddress(m.protocolAddress[:]), client)
+	teleporterMessenger, err := teleportermessenger.NewTeleporterMessenger(m.protocolAddress, client)
 	if err != nil {
 		panic("Failed to get teleporter messenger contract")
 	}

--- a/messages/teleporter/message_manager_test.go
+++ b/messages/teleporter/message_manager_test.go
@@ -30,7 +30,7 @@ type CallContractChecker struct {
 }
 
 var (
-	messageProtocolAddress = common.HexToHash("0xd81545385803bCD83bd59f58Ba2d2c0562387F83")
+	messageProtocolAddress = common.HexToAddress("0xd81545385803bCD83bd59f58Ba2d2c0562387F83")
 	messageProtocolConfig  = config.MessageProtocolConfig{
 		MessageFormat: config.TELEPORTER.String(),
 		Settings: map[string]interface{}{
@@ -211,13 +211,12 @@ func TestShouldSendMessage(t *testing.T) {
 			ethClient := mock_evm.NewMockClient(ctrl)
 			mockClient.EXPECT().Client().Return(ethClient).Times(test.clientTimes)
 			mockClient.EXPECT().SenderAddress().Return(test.senderAddressResult).Times(test.senderAddressTimes)
-			protocolAddress := common.BytesToAddress(messageProtocolAddress[:])
 			if test.calculateMessageIDCall != nil {
-				messageIDInput := interfaces.CallMsg{From: bind.CallOpts{}.From, To: &protocolAddress, Data: test.calculateMessageIDCall.input}
+				messageIDInput := interfaces.CallMsg{From: bind.CallOpts{}.From, To: &messageProtocolAddress, Data: test.calculateMessageIDCall.input}
 				ethClient.EXPECT().CallContract(gomock.Any(), gomock.Eq(messageIDInput), gomock.Any()).Return(test.calculateMessageIDCall.expectedResult, nil).Times(test.calculateMessageIDCall.times)
 			}
 			if test.messageReceivedCall != nil {
-				messageReceivedInput := interfaces.CallMsg{From: bind.CallOpts{}.From, To: &protocolAddress, Data: test.messageReceivedCall.input}
+				messageReceivedInput := interfaces.CallMsg{From: bind.CallOpts{}.From, To: &messageProtocolAddress, Data: test.messageReceivedCall.input}
 				ethClient.EXPECT().CallContract(gomock.Any(), gomock.Eq(messageReceivedInput), gomock.Any()).Return(test.messageReceivedCall.expectedResult, nil).Times(test.messageReceivedCall.times)
 			}
 

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -47,7 +47,7 @@ type Relayer struct {
 	sourceBlockchainID       ids.ID
 	responseChan             chan message.InboundMessage
 	contractMessage          vms.ContractMessage
-	messageManagers          map[common.Hash]messages.MessageManager
+	messageManagers          map[common.Address]messages.MessageManager
 	logger                   logging.Logger
 	metrics                  *MessageRelayerMetrics
 	db                       database.RelayerDatabase
@@ -102,10 +102,10 @@ func NewRelayer(
 	}
 
 	// Create message managers for each supported message protocol
-	messageManagers := make(map[common.Hash]messages.MessageManager)
-	for address, config := range sourceSubnetInfo.MessageContracts {
-		addressHash := common.HexToHash(address)
-		messageManager, err := messages.NewMessageManager(logger, addressHash, config, filteredDestinationClients)
+	messageManagers := make(map[common.Address]messages.MessageManager)
+	for addressStr, config := range sourceSubnetInfo.MessageContracts {
+		address := common.HexToAddress(addressStr)
+		messageManager, err := messages.NewMessageManager(logger, address, config, filteredDestinationClients)
 		if err != nil {
 			logger.Error(
 				"Failed to create message manager",
@@ -113,7 +113,7 @@ func NewRelayer(
 			)
 			return nil, err
 		}
-		messageManagers[addressHash] = messageManager
+		messageManagers[address] = messageManager
 	}
 
 	uri := utils.StripFromString(sourceSubnetInfo.GetNodeRPCEndpoint(), "/ext")

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -105,6 +105,7 @@ func (s *subscriber) NewWarpLogInfo(log types.Log) (*vmtypes.WarpLogInfo, error)
 	}
 
 	return &vmtypes.WarpLogInfo{
+		// BytesToAddress takes the last 20 bytes of the byte array if it is longer than 20 bytes
 		SourceAddress:    common.BytesToAddress(log.Topics[1][:]),
 		SourceTxID:       log.TxHash[:],
 		UnsignedMsgBytes: log.Data,

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -105,7 +105,7 @@ func (s *subscriber) NewWarpLogInfo(log types.Log) (*vmtypes.WarpLogInfo, error)
 	}
 
 	return &vmtypes.WarpLogInfo{
-		SourceAddress:    log.Topics[1],
+		SourceAddress:    common.BytesToAddress(log.Topics[1][:]),
 		SourceTxID:       log.TxHash[:],
 		UnsignedMsgBytes: log.Data,
 		BlockNumber:      log.BlockNumber,

--- a/vms/vmtypes/message_info.go
+++ b/vms/vmtypes/message_info.go
@@ -11,7 +11,7 @@ import (
 // describes the transaction information emitted by the source chain,
 // including the Warp Message payload bytes
 type WarpLogInfo struct {
-	SourceAddress    common.Hash
+	SourceAddress    common.Address
 	SourceTxID       []byte
 	UnsignedMsgBytes []byte
 	BlockNumber      uint64


### PR DESCRIPTION
## Why this should be merged
Closes https://github.com/ava-labs/awm-relayer/issues/131

## How this works
The only place that gives back a `common.Hash` is the warp logs. We convert this into a `common.Address` instead of the other way around.

## How this was tested
Existing tests