### PR TITLE
Use crypto library for private keys

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/big"
 	"net/url"
 	"os"
 
@@ -395,17 +394,12 @@ func (s *SourceSubnet) GetNodeWSEndpoint() string {
 
 // Get the private key and derive the wallet address from a relayer's configured private key for a given destination subnet.
 func (s *DestinationSubnet) GetRelayerAccountInfo() (*ecdsa.PrivateKey, common.Address, error) {
-	var ok bool
-	pk := new(ecdsa.PrivateKey)
-	pk.D, ok = new(big.Int).SetString(s.AccountPrivateKey, 16)
-	if !ok {
-		return nil, common.Address{}, ErrInvalidPrivateKey
+	pk, err := crypto.HexToECDSA(s.AccountPrivateKey)
+	if err != nil {
+		return nil, common.Address{}, err
 	}
-	pk.PublicKey.Curve = crypto.S256()
-	pk.PublicKey.X, pk.PublicKey.Y = pk.PublicKey.Curve.ScalarBaseMult(pk.D.Bytes())
-	pkBytes := pk.PublicKey.X.Bytes()
-	pkBytes = append(pkBytes, pk.PublicKey.Y.Bytes()...)
-	return pk, common.BytesToAddress(crypto.Keccak256(pkBytes)), nil
+
+	return pk, crypto.PubkeyToAddress(pk.PublicKey), nil
 }
 
 //

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,6 @@ package config
 import (
 	"crypto/ecdsa"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -25,10 +24,6 @@ const (
 	relayerPrivateKeyBytes      = 32
 	accountPrivateKeyEnvVarName = "ACCOUNT_PRIVATE_KEY"
 	cChainIdentifierString      = "C"
-)
-
-var (
-	ErrInvalidPrivateKey = errors.New("failed to set private key string")
 )
 
 type MessageProtocolConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,6 +6,7 @@ package config
 import (
 	"crypto/ecdsa"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -245,7 +246,7 @@ func TestGetRelayerAccountInfo(t *testing.T) {
 					D: big.NewInt(-5567472993773453273),
 				},
 				addr: common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"),
-				err:  ErrInvalidPrivateKey,
+				err:  errors.New("invalid hex character 'x' in private key"),
 			},
 		},
 		{
@@ -258,7 +259,7 @@ func TestGetRelayerAccountInfo(t *testing.T) {
 					D: big.NewInt(-5567472993773453273),
 				},
 				addr: common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"),
-				err:  ErrInvalidPrivateKey,
+				err:  errors.New("invalid hex character 'i' in private key"),
 			},
 		},
 	}


### PR DESCRIPTION
## Why this should be merged
We reimplemented populating the private key struct before we knew that the crypto library would do it for us.

## How this works
Uses crypto library to create a private key from a hex string.

## How this was tested
existing tests