### PR TITLE
Use message ID utility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,11 @@ module github.com/ava-labs/awm-relayer
 go 1.20
 
 require (
+	github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0
 	github.com/ava-labs/avalanchego v1.10.18
 	github.com/ava-labs/coreth v0.12.10-rc.5
 	github.com/ava-labs/subnet-evm v0.5.11
-	github.com/ava-labs/teleporter v0.1.1-0.20240125232816-d92ef8e89b7a
+	github.com/ava-labs/teleporter v0.1.1-0.20240131201856-c009201acf80
 	github.com/ethereum/go-ethereum v1.12.0
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.1
@@ -21,7 +22,6 @@ require (
 
 require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
-	github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0 // indirect
 	github.com/cockroachdb/errors v1.9.1 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,10 +69,8 @@ github.com/ava-labs/coreth v0.12.10-rc.5 h1:FMVvXHssvMQ3Eade7i85Wsx9tuD3kUOFMG8k
 github.com/ava-labs/coreth v0.12.10-rc.5/go.mod h1:a58HbIBc9jscGc3aL8e7JuG8RfhBBOm63waq1q0YM+U=
 github.com/ava-labs/subnet-evm v0.5.11 h1:82iddT/ahXNpwc3TBhxMDS1g6bt+Fmsb3kCyJr9qpWs=
 github.com/ava-labs/subnet-evm v0.5.11/go.mod h1:Uv8eYNjj9Kf8S57yxoQd+IpZH/DRLvbm6yeygUDZuE4=
-github.com/ava-labs/teleporter v0.1.1-0.20240125203414-e714ebbb20f9 h1:8VafqUVEIG36ewXkFQe3baSNntlhaz21xux+62OA1jg=
-github.com/ava-labs/teleporter v0.1.1-0.20240125203414-e714ebbb20f9/go.mod h1:B6bFTJKtR2kD3wHLtAEtWa/EjlrZwLlOgKyvMw3NMNE=
-github.com/ava-labs/teleporter v0.1.1-0.20240125232816-d92ef8e89b7a h1:OqvC6ukcYkJB4o+kEhkRti0OvlLgPtzM7atflmbmD84=
-github.com/ava-labs/teleporter v0.1.1-0.20240125232816-d92ef8e89b7a/go.mod h1:B6bFTJKtR2kD3wHLtAEtWa/EjlrZwLlOgKyvMw3NMNE=
+github.com/ava-labs/teleporter v0.1.1-0.20240131201856-c009201acf80 h1:+e6l5eYJKu+4LyJ91nP8J1SvY/3KtO6ZojFJQNEaQR8=
+github.com/ava-labs/teleporter v0.1.1-0.20240131201856-c009201acf80/go.mod h1:B6bFTJKtR2kD3wHLtAEtWa/EjlrZwLlOgKyvMw3NMNE=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/messages/teleporter/message_manager.go
+++ b/messages/teleporter/message_manager.go
@@ -126,7 +126,7 @@ func (m *messageManager) ShouldSendMessage(unsignedMessage *warp.UnsignedMessage
 
 	teleporterMessageID, err := teleporterutils.CalculateMessageID(m.protocolAddress, unsignedMessage.SourceChainID, destinationBlockchainID, teleporterMessage.MessageNonce)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to calculate Teleporter message ID: %w", err)
 	}
 
 	senderAddress := destinationClient.SenderAddress()

--- a/messages/teleporter/message_manager.go
+++ b/messages/teleporter/message_manager.go
@@ -188,7 +188,7 @@ func (m *messageManager) SendMessage(signedMessage *warp.Message, destinationBlo
 
 	teleporterMessageID, err := teleporterutils.CalculateMessageID(m.protocolAddress, signedMessage.SourceChainID, destinationBlockchainID, teleporterMessage.MessageNonce)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to calculate Teleporter message ID: %w", err)
 	}
 
 	m.logger.Info(

--- a/messages/teleporter/message_manager.go
+++ b/messages/teleporter/message_manager.go
@@ -6,7 +6,6 @@ package teleporter
 import (
 	"encoding/json"
 	"fmt"
-	"math/big"
 
 	"github.com/ava-labs/avalanchego/cache"
 	"github.com/ava-labs/avalanchego/ids"
@@ -19,6 +18,7 @@ import (
 	"github.com/ava-labs/subnet-evm/ethclient"
 	teleportermessenger "github.com/ava-labs/teleporter/abi-bindings/go/Teleporter/TeleporterMessenger"
 	gasUtils "github.com/ava-labs/teleporter/utils/gas-utils"
+	teleporterutils "github.com/ava-labs/teleporter/utils/teleporter-utils"
 	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
 )
@@ -124,8 +124,7 @@ func (m *messageManager) ShouldSendMessage(unsignedMessage *warp.UnsignedMessage
 		return false, fmt.Errorf("relayer not configured to deliver to destination. destinationBlockchainID=%s", destinationBlockchainID.String())
 	}
 
-	teleporterMessenger := m.getTeleporterMessenger(destinationClient)
-	teleporterMessageID, err := m.calculateMessageID(teleporterMessenger, unsignedMessage.SourceChainID, destinationBlockchainID, teleporterMessage.MessageNonce)
+	teleporterMessageID, err := teleporterutils.CalculateMessageID(m.protocolAddress, unsignedMessage.SourceChainID, destinationBlockchainID, teleporterMessage.MessageNonce)
 	if err != nil {
 		return false, err
 	}
@@ -142,6 +141,7 @@ func (m *messageManager) ShouldSendMessage(unsignedMessage *warp.UnsignedMessage
 	}
 
 	// Check if the message has already been delivered to the destination chain
+	teleporterMessenger := m.getTeleporterMessenger(destinationClient)
 	delivered, err := teleporterMessenger.MessageReceived(&bind.CallOpts{}, teleporterMessageID)
 	if err != nil {
 		m.logger.Error(
@@ -186,8 +186,7 @@ func (m *messageManager) SendMessage(signedMessage *warp.Message, destinationBlo
 		return fmt.Errorf("relayer not configured to deliver to destination. DestinationBlockchainID=%s", destinationBlockchainID)
 	}
 
-	teleporterMessenger := m.getTeleporterMessenger(destinationClient)
-	teleporterMessageID, err := m.calculateMessageID(teleporterMessenger, signedMessage.SourceChainID, destinationBlockchainID, teleporterMessage.MessageNonce)
+	teleporterMessageID, err := teleporterutils.CalculateMessageID(m.protocolAddress, signedMessage.SourceChainID, destinationBlockchainID, teleporterMessage.MessageNonce)
 	if err != nil {
 		return err
 	}
@@ -296,19 +295,4 @@ func (m *messageManager) getTeleporterMessenger(destinationClient vms.Destinatio
 		panic("Failed to get teleporter messenger contract")
 	}
 	return teleporterMessenger
-}
-
-func (m *messageManager) calculateMessageID(teleporter *teleportermessenger.TeleporterMessenger, sourceBlockchainID ids.ID, destinationBlockchainID ids.ID, messageNonce *big.Int) (ids.ID, error) {
-	messageID, err := teleporter.CalculateMessageID(&bind.CallOpts{}, sourceBlockchainID, destinationBlockchainID, messageNonce)
-	if err != nil {
-		m.logger.Error(
-			"Failed to calculate message ID",
-			zap.String("sourceBlockchainID", sourceBlockchainID.String()),
-			zap.String("destinationBlockchainID", destinationBlockchainID.String()),
-			zap.Error(err),
-		)
-		return ids.Empty, err
-	}
-
-	return messageID, nil
 }

--- a/messages/teleporter/message_manager_test.go
+++ b/messages/teleporter/message_manager_test.go
@@ -4,7 +4,6 @@
 package teleporter
 
 import (
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -115,7 +114,6 @@ func TestShouldSendMessage(t *testing.T) {
 		senderAddressTimes      int
 		clientTimes             int
 		messageReceivedCall     *CallContractChecker
-		messageIDOutput         []byte
 		expectedError           bool
 		expectedResult          bool
 	}{
@@ -171,13 +169,12 @@ func TestShouldSendMessage(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			fmt.Println(test.name)
 			ethClient := mock_evm.NewMockClient(ctrl)
 			mockClient.EXPECT().Client().Return(ethClient).Times(test.clientTimes)
 			mockClient.EXPECT().SenderAddress().Return(test.senderAddressResult).Times(test.senderAddressTimes)
 			if test.messageReceivedCall != nil {
 				messageReceivedInput := interfaces.CallMsg{From: bind.CallOpts{}.From, To: &messageProtocolAddress, Data: test.messageReceivedCall.input}
-				ethClient.EXPECT().CallContract(gomock.Any(), gomock.Eq(messageReceivedInput), gomock.Any()).Return(test.messageReceivedCall.expectedResult, nil).Times(0)
+				ethClient.EXPECT().CallContract(gomock.Any(), gomock.Eq(messageReceivedInput), gomock.Any()).Return(test.messageReceivedCall.expectedResult, nil).Times(test.messageReceivedCall.times)
 			}
 
 			result, err := messageManager.ShouldSendMessage(test.warpUnsignedMessage, test.destinationBlockchainID)

--- a/tests/basic_relay.go
+++ b/tests/basic_relay.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ava-labs/teleporter/tests/interfaces"
 	"github.com/ava-labs/teleporter/tests/utils"
 	teleporterTestUtils "github.com/ava-labs/teleporter/tests/utils"
+	teleporterutils "github.com/ava-labs/teleporter/utils/teleporter-utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -81,6 +82,7 @@ func BasicRelay(network interfaces.LocalNetwork) {
 	log.Info("Sending transaction from Subnet A to Subnet B")
 	relayBasicMessage(
 		ctx,
+		teleporterContractAddress,
 		subnetAInfo,
 		subnetBInfo,
 		fundedKey,
@@ -93,6 +95,7 @@ func BasicRelay(network interfaces.LocalNetwork) {
 	log.Info("Test Relaying from Subnet B to Subnet A")
 	relayBasicMessage(
 		ctx,
+		teleporterContractAddress,
 		subnetBInfo,
 		subnetAInfo,
 		fundedKey,
@@ -226,6 +229,7 @@ func sendBasicTeleporterMessage(
 
 func relayBasicMessage(
 	ctx context.Context,
+	teleporterContractAddress common.Address,
 	source interfaces.SubnetTestInfo,
 	destination interfaces.SubnetTestInfo,
 	fundedKey *ecdsa.PrivateKey,
@@ -300,7 +304,13 @@ func relayBasicMessage(
 	receivedTeleporterMessage, err := teleportermessenger.UnpackTeleporterMessage(addressedPayload.Payload)
 	Expect(err).Should(BeNil())
 
-	receivedMessageID := teleporterTestUtils.CalculateMessageID(source, destination, teleporterMessage.MessageNonce)
+	receivedMessageID, err := teleporterutils.CalculateMessageID(
+		teleporterContractAddress,
+		source.BlockchainID,
+		destination.BlockchainID,
+		teleporterMessage.MessageNonce,
+	)
+	Expect(err).Should(BeNil())
 	Expect(receivedMessageID).Should(Equal(teleporterMessageID))
 	Expect(receivedTeleporterMessage.OriginSenderAddress).Should(Equal(teleporterMessage.OriginSenderAddress))
 	receivedDestinationID, err := ids.ToID(receivedTeleporterMessage.DestinationBlockchainID[:])

--- a/tests/teleporter_registry.go
+++ b/tests/teleporter_registry.go
@@ -58,9 +58,9 @@ func TeleporterRegistry(network interfaces.LocalNetwork) {
 	// Set up the nodes to accept the off-chain message
 	//
 	// Create chain config file with off chain message for each chain
-	unsignedMessage, warpEnabledChainConfigC := utils.InitChainConfig(networkID, cChainInfo, newProtocolAddress)
-	_, warpEnabledChainConfigA := utils.InitChainConfig(networkID, subnetAInfo, newProtocolAddress)
-	_, warpEnabledChainConfigB := utils.InitChainConfig(networkID, subnetBInfo, newProtocolAddress)
+	unsignedMessage, warpEnabledChainConfigC := utils.InitChainConfig(networkID, cChainInfo, newProtocolAddress, 2)
+	_, warpEnabledChainConfigA := utils.InitChainConfig(networkID, subnetAInfo, newProtocolAddress, 2)
+	_, warpEnabledChainConfigB := utils.InitChainConfig(networkID, subnetBInfo, newProtocolAddress, 2)
 
 	// Create chain config with off chain messages
 	chainConfigs := make(map[string]string)


### PR DESCRIPTION
## Why this should be merged
Closes https://github.com/ava-labs/awm-relayer/issues/136

## How this works
Uses a utility in the Teleporter repo to calculated the Teleporter Message ID without having to make an API call to a node.

## How this was tested
Tested in the Teleporter repo.