### PR TITLE
Use teleporter message ID utility

### DIFF
--- a/messages/teleporter/message_manager.go
+++ b/messages/teleporter/message_manager.go
@@ -17,8 +17,8 @@ import (
 	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
 	"github.com/ava-labs/subnet-evm/ethclient"
 	teleportermessenger "github.com/ava-labs/teleporter/abi-bindings/go/Teleporter/TeleporterMessenger"
-	teleporterUtils "github.com/ava-labs/teleporter/utils/teleporter-utils"
 	gasUtils "github.com/ava-labs/teleporter/utils/gas-utils"
+	teleporterUtils "github.com/ava-labs/teleporter/utils/teleporter-utils"
 	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
 )

--- a/messages/teleporter/message_manager.go
+++ b/messages/teleporter/message_manager.go
@@ -6,7 +6,6 @@ package teleporter
 import (
 	"encoding/json"
 	"fmt"
-	"math/big"
 
 	"github.com/ava-labs/avalanchego/cache"
 	"github.com/ava-labs/avalanchego/ids"
@@ -18,6 +17,7 @@ import (
 	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
 	"github.com/ava-labs/subnet-evm/ethclient"
 	teleportermessenger "github.com/ava-labs/teleporter/abi-bindings/go/Teleporter/TeleporterMessenger"
+	teleporterUtils "github.com/ava-labs/teleporter/utils/teleporter-utils"
 	gasUtils "github.com/ava-labs/teleporter/utils/gas-utils"
 	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
@@ -124,10 +124,14 @@ func (m *messageManager) ShouldSendMessage(warpMessageInfo *vmtypes.WarpMessageI
 		return false, fmt.Errorf("relayer not configured to deliver to destination. destinationBlockchainID=%s", destinationBlockchainID.String())
 	}
 
-	teleporterMessenger := m.getTeleporterMessenger(destinationClient)
-	teleporterMessageID, err := m.calculateMessageID(teleporterMessenger, warpMessageInfo.WarpUnsignedMessage.SourceChainID, destinationBlockchainID, teleporterMessage.MessageNonce)
+	teleporterMessageID, err := teleporterUtils.CalculateMessageID(
+		m.protocolAddress,
+		warpMessageInfo.WarpUnsignedMessage.SourceChainID,
+		destinationBlockchainID,
+		teleporterMessage.MessageNonce,
+	)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to calculate Teleporter message ID: %w", err)
 	}
 
 	senderAddress := destinationClient.SenderAddress()
@@ -142,6 +146,7 @@ func (m *messageManager) ShouldSendMessage(warpMessageInfo *vmtypes.WarpMessageI
 	}
 
 	// Check if the message has already been delivered to the destination chain
+	teleporterMessenger := m.getTeleporterMessenger(destinationClient)
 	delivered, err := teleporterMessenger.MessageReceived(&bind.CallOpts{}, teleporterMessageID)
 	if err != nil {
 		m.logger.Error(
@@ -186,10 +191,14 @@ func (m *messageManager) SendMessage(signedMessage *warp.Message, parsedVmPayloa
 		return fmt.Errorf("relayer not configured to deliver to destination. DestinationBlockchainID=%s", destinationBlockchainID)
 	}
 
-	teleporterMessenger := m.getTeleporterMessenger(destinationClient)
-	teleporterMessageID, err := m.calculateMessageID(teleporterMessenger, signedMessage.SourceChainID, destinationBlockchainID, teleporterMessage.MessageNonce)
+	teleporterMessageID, err := teleporterUtils.CalculateMessageID(
+		m.protocolAddress,
+		signedMessage.SourceChainID,
+		destinationBlockchainID,
+		teleporterMessage.MessageNonce,
+	)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to calculate Teleporter message ID: %w", err)
 	}
 
 	m.logger.Info(
@@ -289,19 +298,4 @@ func (m *messageManager) getTeleporterMessenger(destinationClient vms.Destinatio
 		panic("Failed to get teleporter messenger contract")
 	}
 	return teleporterMessenger
-}
-
-func (m *messageManager) calculateMessageID(teleporter *teleportermessenger.TeleporterMessenger, sourceBlockchainID ids.ID, destinationBlockchainID ids.ID, messageNonce *big.Int) (ids.ID, error) {
-	messageID, err := teleporter.CalculateMessageID(&bind.CallOpts{}, sourceBlockchainID, destinationBlockchainID, messageNonce)
-	if err != nil {
-		m.logger.Error(
-			"Failed to calculate message ID",
-			zap.String("sourceBlockchainID", sourceBlockchainID.String()),
-			zap.String("destinationBlockchainID", destinationBlockchainID.String()),
-			zap.Error(err),
-		)
-		return ids.Empty, err
-	}
-
-	return messageID, nil
 }

--- a/messages/teleporter/message_manager_test.go
+++ b/messages/teleporter/message_manager_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
 	"github.com/ava-labs/subnet-evm/interfaces"
 	teleportermessenger "github.com/ava-labs/teleporter/abi-bindings/go/Teleporter/TeleporterMessenger"
+	teleporterUtils "github.com/ava-labs/teleporter/utils/teleporter-utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -38,7 +39,6 @@ var (
 		},
 	}
 	destinationBlockchainIDString = "S4mMqUXe7vHsGiRAma6bv3CKnyaLssyAxmQ2KvFpX1KEvfFCD"
-	messageIDstring               = "2CQw6XkzbDZY87XRomuszWkCBDTUvMaZv3YE2PAf7cicxWWEMF"
 	validRelayerAddress           = common.HexToAddress("0x0123456789abcdef0123456789abcdef01234567")
 	validTeleporterMessage        = teleportermessenger.TeleporterMessage{
 		MessageNonce:        big.NewInt(1),
@@ -84,18 +84,7 @@ func TestShouldSendMessage(t *testing.T) {
 	warpUnsignedMessage, err := warp.NewUnsignedMessage(0, sourceBlockchainID, validMessageBytes)
 	require.NoError(t, err)
 
-	// Create all the inputs and expected outputs for Teleporter calls
-	calculateMessageIDInput, err := teleportermessenger.PackCalculateMessageID(
-		sourceBlockchainID,
-		destinationBlockchainID,
-		validTeleporterMessage.MessageNonce,
-	)
-	require.NoError(t, err)
-
-	messageID, err := ids.FromString(messageIDstring)
-	require.NoError(t, err)
-
-	messageIDOutput, err := teleportermessenger.PackCalculateMessageIDOutput(messageID)
+	messageID, err := teleporterUtils.CalculateMessageID(messageProtocolAddress, sourceBlockchainID, destinationBlockchainID, validTeleporterMessage.MessageNonce)
 	require.NoError(t, err)
 
 	messageReceivedInput, err := teleportermessenger.PackMessageReceived(messageID)
@@ -121,7 +110,6 @@ func TestShouldSendMessage(t *testing.T) {
 		senderAddressResult     common.Address
 		senderAddressTimes      int
 		clientTimes             int
-		calculateMessageIDCall  *CallContractChecker
 		messageReceivedCall     *CallContractChecker
 		expectedError           bool
 		expectedResult          bool
@@ -136,11 +124,6 @@ func TestShouldSendMessage(t *testing.T) {
 			senderAddressResult: validRelayerAddress,
 			senderAddressTimes:  1,
 			clientTimes:         1,
-			calculateMessageIDCall: &CallContractChecker{
-				input:          calculateMessageIDInput,
-				expectedResult: messageIDOutput,
-				times:          1,
-			},
 			messageReceivedCall: &CallContractChecker{
 				input:          messageReceivedInput,
 				expectedResult: messageNotDelivered,
@@ -175,13 +158,8 @@ func TestShouldSendMessage(t *testing.T) {
 			},
 			senderAddressResult: common.Address{},
 			senderAddressTimes:  1,
-			clientTimes:         1,
-			calculateMessageIDCall: &CallContractChecker{
-				input:          calculateMessageIDInput,
-				expectedResult: messageIDOutput,
-				times:          1,
-			},
-			expectedResult: false,
+			clientTimes:         0,
+			expectedResult:      false,
 		},
 		{
 			name:                    "message already delivered",
@@ -193,11 +171,6 @@ func TestShouldSendMessage(t *testing.T) {
 			senderAddressResult: validRelayerAddress,
 			senderAddressTimes:  1,
 			clientTimes:         1,
-			calculateMessageIDCall: &CallContractChecker{
-				input:          calculateMessageIDInput,
-				expectedResult: messageIDOutput,
-				times:          1,
-			},
 			messageReceivedCall: &CallContractChecker{
 				input:          messageReceivedInput,
 				expectedResult: messageDelivered,
@@ -211,10 +184,6 @@ func TestShouldSendMessage(t *testing.T) {
 			ethClient := mock_evm.NewMockClient(ctrl)
 			mockClient.EXPECT().Client().Return(ethClient).Times(test.clientTimes)
 			mockClient.EXPECT().SenderAddress().Return(test.senderAddressResult).Times(test.senderAddressTimes)
-			if test.calculateMessageIDCall != nil {
-				messageIDInput := interfaces.CallMsg{From: bind.CallOpts{}.From, To: &messageProtocolAddress, Data: test.calculateMessageIDCall.input}
-				ethClient.EXPECT().CallContract(gomock.Any(), gomock.Eq(messageIDInput), gomock.Any()).Return(test.calculateMessageIDCall.expectedResult, nil).Times(test.calculateMessageIDCall.times)
-			}
 			if test.messageReceivedCall != nil {
 				messageReceivedInput := interfaces.CallMsg{From: bind.CallOpts{}.From, To: &messageProtocolAddress, Data: test.messageReceivedCall.input}
 				ethClient.EXPECT().CallContract(gomock.Any(), gomock.Eq(messageReceivedInput), gomock.Any()).Return(test.messageReceivedCall.expectedResult, nil).Times(test.messageReceivedCall.times)


### PR DESCRIPTION
## Why this should be merged
Closes https://github.com/ava-labs/awm-relayer/issues/136, supersedes https://github.com/ava-labs/awm-relayer/pull/160

## How this works
Uses a utility in the Teleporter repo to calculated the Teleporter Message ID without having to make an API call to a node.

## How this was tested
Tested in the Teleporter repo.