### PR TITLE
Improve tests error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ava-labs/awm-relayer
 go 1.20
 
 require (
+	github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0
 	github.com/ava-labs/avalanchego v1.10.18
 	github.com/ava-labs/coreth v0.12.10-rc.5
 	github.com/ava-labs/subnet-evm v0.5.11
@@ -21,7 +22,6 @@ require (
 
 require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
-	github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0 // indirect
 	github.com/cockroachdb/errors v1.9.1 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811 // indirect

--- a/messages/teleporter/message_manager_test.go
+++ b/messages/teleporter/message_manager_test.go
@@ -59,24 +59,8 @@ var (
 )
 
 func TestShouldSendMessage(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	logger := logging.NoLog{}
 	destinationBlockchainID, err := ids.FromString(destinationBlockchainIDString)
 	require.NoError(t, err)
-
-	mockClient := mock_vms.NewMockDestinationClient(ctrl)
-	destinationClients := map[ids.ID]vms.DestinationClient{
-		destinationBlockchainID: mockClient,
-	}
-
-	messageManager, err := NewMessageManager(
-		logger,
-		messageProtocolAddress,
-		messageProtocolConfig,
-		destinationClients,
-	)
-	require.NoError(t, err)
-
 	validMessageBytes, err := teleportermessenger.PackTeleporterMessage(validTeleporterMessage)
 	require.NoError(t, err)
 
@@ -181,6 +165,21 @@ func TestShouldSendMessage(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			logger := logging.NoLog{}
+
+			mockClient := mock_vms.NewMockDestinationClient(ctrl)
+			destinationClients := map[ids.ID]vms.DestinationClient{
+				destinationBlockchainID: mockClient,
+			}
+
+			messageManager, err := NewMessageManager(
+				logger,
+				messageProtocolAddress,
+				messageProtocolConfig,
+				destinationClients,
+			)
+			require.NoError(t, err)
 			ethClient := mock_evm.NewMockClient(ctrl)
 			mockClient.EXPECT().Client().Return(ethClient).Times(test.clientTimes)
 			mockClient.EXPECT().SenderAddress().Return(test.senderAddressResult).Times(test.senderAddressTimes)

--- a/vms/evm/destination_client_test.go
+++ b/vms/evm/destination_client_test.go
@@ -29,18 +29,8 @@ var destinationSubnet = config.DestinationSubnet{
 }
 
 func TestSendTx(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockClient := mock_ethclient.NewMockClient(ctrl)
 	pk, eoa, err := destinationSubnet.GetRelayerAccountInfo()
 	require.NoError(t, err)
-
-	destinationClient := &destinationClient{
-		lock:   &sync.Mutex{},
-		logger: logging.NoLog{},
-		client: mockClient,
-		pk:     pk,
-		eoa:    eoa,
-	}
 
 	testError := fmt.Errorf("call errored")
 	testCases := []struct {
@@ -96,6 +86,15 @@ func TestSendTx(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockClient := mock_ethclient.NewMockClient(ctrl)
+			destinationClient := &destinationClient{
+				lock:   &sync.Mutex{},
+				logger: logging.NoLog{},
+				client: mockClient,
+				pk:     pk,
+				eoa:    eoa,
+			}
 			warpMsg := &avalancheWarp.Message{}
 			toAddress := "0x27aE10273D17Cd7e80de8580A51f476960626e5f"
 


### PR DESCRIPTION
## Why this should be merged
The error printed would indicate the wrong test case failing. We want to log the actual test case that fails.

Also add additional check and test case for `ProcessFromHeight`

## How this works
We need to create the go mock controllers with `gomock.NewController(t)` while we iterate through the test cases to get the correct test case that fails printed in error.

## How this was tested
If you make one of `TestShouldSendMessage` or `TestSendTx` fail on `main` it will print the error indicating the wrong test case failing. Compared to this branch, it'll indicate the correct test case.

For example, I had `TestShouldSendMessage/not_allowed` fail on `main`, but the error prints 
```
    --- FAIL: TestShouldSendMessage/message_already_delivered (0.00s)
        testing.go:1490: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
```
With these changes will print the actual failing error 
```
    --- FAIL: TestShouldSendMessage/not_allowed (0.00s)
        controller.go:98: missing call(s) to *mocks.MockDestinationClient.Client() /Users/matthewlam/go/src/awm-relayer/messages/teleporter/message_manager_test.go:184
```
CI
## How is this documented
n/a