### PR TITLE
Nit: build command syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Build the relayer by running the script:
 
 Build a Docker image by running the script:
 ```
-./scripts/build-local-image.sh
+./scripts/build_local_image.sh
 ```
 
 ### Running


### PR DESCRIPTION
## Why this should be merged

build Docker image command written with `-` instead of `_`

## How this was tested

run  `./scripts/build-local-image.sh` -> 'no such file or directory'
`./scripts/build_local_image.sh` -> builds Docker image successfully 

