### PR TITLE
Update release Dockerfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,5 +73,4 @@ jobs:
         env:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCKERFILE: ./Dockerfile.release
           GO_VERSION: ${{ env.GO_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,3 +74,4 @@ jobs:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKERFILE: ./Dockerfile.release
+          GO_VERSION: ${{ env.GO_VERSION }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,6 +36,7 @@ dockers:
     build_flag_templates:
     - "--pull"
     - "--platform=linux/amd64"
+    - "--build-arg=GO_VERSION={{ .Env.GO_VERSION }}"
   - image_templates:
     - 'avaplatform/awm-relayer:{{ .Tag }}-arm64'
     dockerfile: "{{ .Env.DOCKERFILE }}"
@@ -43,6 +44,7 @@ dockers:
     build_flag_templates:
     - "--pull"
     - "--platform=linux/arm64"
+    - "--build-arg=GO_VERSION={{ .Env.GO_VERSION }}"
     goarch: arm64
 docker_manifests:
   - name_template: 'avaplatform/awm-relayer:{{ .Tag }}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,7 +31,6 @@ builds:
 dockers:
   - image_templates:
     - 'avaplatform/awm-relayer:{{ .Tag }}-amd64'
-    dockerfile: "{{ .Env.DOCKERFILE }}"
     use: buildx
     build_flag_templates:
     - "--pull"
@@ -39,7 +38,6 @@ dockers:
     - "--build-arg=GO_VERSION={{ .Env.GO_VERSION }}"
   - image_templates:
     - 'avaplatform/awm-relayer:{{ .Tag }}-arm64'
-    dockerfile: "{{ .Env.DOCKERFILE }}"
     use: buildx
     build_flag_templates:
     - "--pull"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,7 @@
-### Build Stage ###
-ARG GO_VERSION
-FROM golang:${GO_VERSION}-bullseye as build
-
-WORKDIR /go/src
-# Copy the code into the container
-COPY . .
-RUN go mod tidy
-# Build awm-relayer
-RUN bash ./scripts/build.sh
-
-### RUN Stage ###
 ARG GO_VERSION
 FROM golang:${GO_VERSION}
-COPY --from=build /go/src/build/awm-relayer /usr/bin/awm-relayer
+COPY awm-relayer /usr/bin/awm-relayer
 EXPOSE 8080
 USER 1001
 CMD ["start"]
-ENTRYPOINT ["/usr/bin/awm-relayer"]
+ENTRYPOINT [ "/usr/bin/awm-relayer" ]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,3 +1,7 @@
-FROM debian:11-slim
+ARG GO_VERSION
+FROM golang:${GO_VERSION}
 COPY awm-relayer /usr/bin/awm-relayer
+EXPOSE 8080
+USER 1001
+CMD ["start"]
 ENTRYPOINT [ "/usr/bin/awm-relayer" ]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,7 +1,0 @@
-ARG GO_VERSION
-FROM golang:${GO_VERSION}
-COPY awm-relayer /usr/bin/awm-relayer
-EXPOSE 8080
-USER 1001
-CMD ["start"]
-ENTRYPOINT [ "/usr/bin/awm-relayer" ]


### PR DESCRIPTION
## Why this should be merged
Changes the base image layer of the Dockerfile from `debian:11-slim` to `golang:v1.21.7`. The golang layer contains a wider set of pre-installed binaries necessary for the relayer to work in a cloud environment. For example, `debian:11-slim` does not contain TLS certs, while to golang layer does.

## How this works
- Replaces `debian:11-slim` with `golang:v1.21.7`
- Removes the unused Dockerfile

## How this was tested
Tested by creating release [v0.0.1](https://github.com/ava-labs/awm-relayer/releases/tag/v0.0.1), and testing the published image on darwin/arm64 and linux/amd64 systems.
- This release will be removed after this PR is merged.

## How is this documented
N/A