### PR TITLE
Add devcontainer config and sample relayer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,13 +3,16 @@
 {
 	"name": "Avalanche-DevContainer",
 
-	"build": {
+	/*"build": {
 		"dockerfile": "../Dockerfile",
 		"args": { "GO_VERSION": "latest" }
-	},
+	},*/
+
+	"image": "avaplatform/awm-relayer:latest",
 
 	"runArgs": ["--network=host"],
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	"remoteUser": "root"
+
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 // For format details, see https://aka.ms/devcontainer.json.
 {
-	"name": "Avalanche Warp Messaging Relayer DevContainer",
+	"name": "AWM Relayer DevContainer",
 
 	"image": "golang:latest",
 	"runArgs": ["--network=host"],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,10 @@
 {
 	"name": "Avalanche Warp Messaging Relayer DevContainer",
 
-	"image": "avaplatform/awm-relayer:latest",
+	"image": "golang:latest",
 	"runArgs": ["--network=host"],
 	
-	"remoteUser": "root"
+	"remoteUser": "root",
+
+	"postCreateCommand": "scripts/build.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Avalanche-DevContainer",
+
+	"image": "avaplatform/awm-relayer:latest",
+	"runArgs": ["--network=host"],
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	"remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,11 @@
 {
 	"name": "Avalanche-DevContainer",
 
-	"image": "avaplatform/awm-relayer:latest",
+	"build": {
+		"dockerfile": "../Dockerfile",
+		"args": { "GO_VERSION": "latest" }
+	},
+
 	"runArgs": ["--network=host"],
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,18 +1,8 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+// For format details, see https://aka.ms/devcontainer.json.
 {
-	"name": "Avalanche-DevContainer",
-
-	/*"build": {
-		"dockerfile": "../Dockerfile",
-		"args": { "GO_VERSION": "latest" }
-	},*/
+	"name": "Avalanche Warp Messaging Relayer DevContainer",
 
 	"image": "avaplatform/awm-relayer:latest",
 
-	"runArgs": ["--network=host"],
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	"remoteUser": "root"
-
+	"runArgs": ["--network=host"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"name": "Avalanche Warp Messaging Relayer DevContainer",
 
 	"image": "avaplatform/awm-relayer:latest",
-
-	"runArgs": ["--network=host"]
+	"runArgs": ["--network=host"],
+	
+	"remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,5 +7,9 @@
 	
 	"remoteUser": "root",
 
+	"remoteEnv": {
+		"PATH": "${containerEnv:PATH}:${containerWorkspaceFolder}/build"
+	},
+
 	"postCreateCommand": "scripts/build.sh"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __debug_bin
 
 .vscode*
 
+relayer-config.json
+
 # Ginkgo test outputs
 main.log
 server.log

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Reference relayer implementation for cross-chain Avalanche Warp Message delivery
 
 ## Installation
 
+### Dev Container & Codespace
+
+To get started easily, we provide a Dev Container specification, that can be used using GitHub Codespace or locally using Docker and VS Code. [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers) are a concept that utilizes containerization to create consistent and isolated development environment. You can run them directly on Github by clicking **Code**, switching to the **Codespaces** tab and clicking **Create codespace on main**. Alternatively, you can run them locally with the extensions for [VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) or other code editors.
+
 ### Download Prebuilt Binaries
 
 Prebuilt binaries are available for download from the [releases page](https://github.com/ava-labs/awm-relayer/releases).

--- a/README.md
+++ b/README.md
@@ -90,25 +90,22 @@ The relayer binary accepts a path to a JSON configuration file as the sole argum
 
 The relayer is configured via a JSON file, the path to which is passed in via the `--config-file` command line argument. The following configuration options are available:
 
-`"log-level": "debug" | "info" | "warn" | "error" | "fatal" | "panic"`
+`"log-level": "verbo" | "debug" | "info" | "warn" | "error" | "fatal" | "panic"`
 
 - The log level for the relayer. Defaults to `info`.
-
-`"network-id": unsigned integer`
-
-- The ID of the Avalanche network to which the relayer will connect. Defaults to `1` (Mainnet).
 
 `"p-chain-api-url": string`
 
 - The URL of the Avalanche P-Chain API node to which the relayer will connect. This API node needs to have the following methods enabled:
-  - info.peers
   - platform.getHeight
   - platform.validatedBy
   - platform.getValidatorsAt
 
-`"encrypt-connection": boolean`
+`"info-api-url": string`
 
-- Whether or not to encrypt the connection to the P-Chain API node. Defaults to `true`.
+- The URL of the Avalanche Info API node to which the relayer will connect. This API node needs to have the following methods enabled:
+  - info.peers
+  - info.getNetworkID
 
 `"storage-location": string`
 
@@ -148,39 +145,27 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
   `"subnet-id": string`
 
-  - cb58-encoded Subnet ID
+  - cb58-encoded Subnet ID.
 
   `"blockchain-id": string`
 
-  - cb58-encoded Blockchain ID
+  - cb58-encoded Blockchain ID.
 
   `"vm": string`
 
   - The VM type of the source subnet.
 
-  `"api-node-host": string`
-
-  - The host of the source subnet's API node.
-
-  `"api-node-port": unsigned integer`
-
-  - The port of the source subnet's API node.
-
-  `"encrypt-connection": boolean`
-
-  - Whether or not to encrypt the connection to the source subnet's API node.
-
   `"rpc-endpoint": string`
 
-  - The RPC endpoint of the source subnet's API node. Used in favor of `api-node-host`, `api-node-port`, and `encrypt-connection` when constructing the endpoint
+  - The RPC endpoint of the source subnet's API node.
 
   `"ws-endpoint": string`
 
-  - The WebSocket endpoint of the source subnet's API node. Used in favor of `api-node-host`, `api-node-port`, and `encrypt-connection` when constructing the endpoint
+  - The WebSocket endpoint of the source subnet's API node.
 
   `"message-contracts": map[string]MessageProtocolConfig`
 
-  - Map of contract addresses to the config options of the protocol at that address. Each `MessageProtocolConfig` consists of a unique `message-format` name, and the raw JSON `settings`
+  - Map of contract addresses to the config options of the protocol at that address. Each `MessageProtocolConfig` consists of a unique `message-format` name, and the raw JSON `settings`.
 
   `"supported-destinations": []string`
 
@@ -196,31 +181,19 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
   `"subnet-id": string`
 
-  - cb58-encoded Subnet ID
+  - cb58-encoded Subnet ID.
 
   `"blockchain-id": string`
 
-  - cb58-encoded Blockchain ID
+  - cb58-encoded Blockchain ID.
 
   `"vm": string`
 
   - The VM type of the source subnet.
 
-  `"api-node-host": string`
-
-  - The host of the source subnet's API node.
-
-  `"api-node-port": unsigned integer`
-
-  - The port of the source subnet's API node.
-
-  `"encrypt-connection": boolean`
-
-  - Whether or not to encrypt the connection to the source subnet's API node.
-
   `"rpc-endpoint": string`
 
-  - The RPC endpoint of the destination subnet's API node. Used in favor of `api-node-host`, `api-node-port`, and `encrypt-connection` when constructing the endpoint
+  - The RPC endpoint of the destination subnet's API node.
 
   `"account-private-key": string`
 

--- a/config/config.go
+++ b/config/config.go
@@ -101,6 +101,7 @@ type Config struct {
 func SetDefaultConfigValues(v *viper.Viper) {
 	v.SetDefault(LogLevelKey, logging.Info.String())
 	v.SetDefault(StorageLocationKey, "./.awm-relayer-storage")
+	v.SetDefault(ProcessMissedBlocksKey, false)
 }
 
 // BuildConfig constructs the relayer config using Viper.

--- a/config/config.go
+++ b/config/config.go
@@ -101,7 +101,7 @@ type Config struct {
 func SetDefaultConfigValues(v *viper.Viper) {
 	v.SetDefault(LogLevelKey, logging.Info.String())
 	v.SetDefault(StorageLocationKey, "./.awm-relayer-storage")
-	v.SetDefault(ProcessMissedBlocksKey, false)
+	v.SetDefault(ProcessMissedBlocksKey, true)
 }
 
 // BuildConfig constructs the relayer config using Viper.

--- a/sample-relayer-config.json
+++ b/sample-relayer-config.json
@@ -9,7 +9,7 @@
       "rpc-endpoint": "https://api.avax-test.network/ext/bc/C/rpc",
       "ws-endpoint": "wss://api.avax-test.network/ext/bc/C/ws",
       "message-contracts": {
-        "0x1CEfA23287eB4aa3012AEB8A0cdF240919a2C237": {
+        "0xF7cBd95f1355f0d8d659864b92e2e9fbfaB786f7": {
           "message-format": "teleporter",
           "settings": {
             "reward-address": "0x5072..."

--- a/sample-relayer-config.json
+++ b/sample-relayer-config.json
@@ -1,0 +1,33 @@
+{
+    "network-id": 1337,
+    "p-chain-api-url": "https://api.avax-test.network/ext/bc/P",
+    "encrypt-connection": false,
+    "process-missed-blocks": false,
+    "source-subnets": [
+      {
+        "subnet-id": "11111111111111111111111111111111LpoYY",
+        "blockchain-id": "yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp",
+        "vm": "evm",
+        "rpc-endpoint": "https://api.avax-test.network/ext/bc/C/rpc",
+        "encrypt-connection": false,
+        "message-contracts": {
+          "0x1CEfA23287eB4aa3012AEB8A0cdF240919a2C237": {
+            "message-format": "teleporter",
+            "settings": {
+              "reward-address": "0x3f86Db..."
+            }
+          }
+        }
+      }
+    ],
+    "destination-subnets": [
+      {
+        "subnet-id": "7WtoAMPhrmh5KosDUsFL9yTcvw7YSxiKHPpdfs4JsgW47oZT5",
+        "blockchain-id": "2D8RG4UpSXbPbvPCAWppNJyqTG2i2CAXSkTgmTBBvs7GKNZjsY",
+        "vm":"evm",
+        "rpc-endpoint": "https://subnets.avax.network/dispatch/testnet/rpc",
+        "encrypt-connection": false,
+        "account-private-key": "0x79987..."
+      }
+    ]
+  }

--- a/sample-relayer-config.json
+++ b/sample-relayer-config.json
@@ -1,7 +1,7 @@
 {
   "info-api-url": "https://api.avax-test.network",
   "p-chain-api-url": "https://api.avax-test.network",
-  "source-subnets": [
+  "source-blockchains": [
     {
       "subnet-id": "11111111111111111111111111111111LpoYY",
       "blockchain-id": "yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp",
@@ -18,7 +18,7 @@
       }
     }
   ],
-  "destination-subnets": [
+  "destination-blockchains": [
     {
       "subnet-id": "7WtoAMPhrmh5KosDUsFL9yTcvw7YSxiKHPpdfs4JsgW47oZT5",
       "blockchain-id": "2D8RG4UpSXbPbvPCAWppNJyqTG2i2CAXSkTgmTBBvs7GKNZjsY",

--- a/sample-relayer-config.json
+++ b/sample-relayer-config.json
@@ -1,9 +1,6 @@
 {
-  "network-id": 5,
+  "info-api-url": "https://api.avax-test.network",
   "p-chain-api-url": "https://api.avax-test.network",
-  "encrypt-connection": true,
-  "process-missed-blocks": false,
-  "log-level": "info",
   "source-subnets": [
     {
       "subnet-id": "11111111111111111111111111111111LpoYY",
@@ -11,7 +8,6 @@
       "vm": "evm",
       "rpc-endpoint": "https://api.avax-test.network/ext/bc/C/rpc",
       "ws-endpoint": "wss://api.avax-test.network/ext/bc/C/ws",
-      "encrypt-connection": true,
       "message-contracts": {
         "0x1CEfA23287eB4aa3012AEB8A0cdF240919a2C237": {
           "message-format": "teleporter",
@@ -28,7 +24,6 @@
       "blockchain-id": "2D8RG4UpSXbPbvPCAWppNJyqTG2i2CAXSkTgmTBBvs7GKNZjsY",
       "vm":"evm",
       "rpc-endpoint": "https://subnets.avax.network/dispatch/testnet/rpc",
-      "encrypt-connection": true,
       "account-private-key": "0x7493..."
     }
   ]

--- a/sample-relayer-config.json
+++ b/sample-relayer-config.json
@@ -5,6 +5,7 @@
     {
       "subnet-id": "11111111111111111111111111111111LpoYY",
       "blockchain-id": "yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp",
+      "start-block-height": ...,
       "vm": "evm",
       "rpc-endpoint": "https://api.avax-test.network/ext/bc/C/rpc",
       "ws-endpoint": "wss://api.avax-test.network/ext/bc/C/ws",

--- a/sample-relayer-config.json
+++ b/sample-relayer-config.json
@@ -1,33 +1,35 @@
 {
-    "network-id": 1337,
-    "p-chain-api-url": "https://api.avax-test.network",
-    "encrypt-connection": false,
-    "process-missed-blocks": false,
-    "source-subnets": [
-      {
-        "subnet-id": "11111111111111111111111111111111LpoYY",
-        "blockchain-id": "yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp",
-        "vm": "evm",
-        "rpc-endpoint": "https://api.avax-test.network/ext/bc/C/rpc",
-        "encrypt-connection": false,
-        "message-contracts": {
-          "0x1CEfA23287eB4aa3012AEB8A0cdF240919a2C237": {
-            "message-format": "teleporter",
-            "settings": {
-              "reward-address": "0x5072b3Df8BD18eaB581e193Ba4d32573C1cB1079"
-            }
+  "network-id": 5,
+  "p-chain-api-url": "https://api.avax-test.network",
+  "encrypt-connection": true,
+  "process-missed-blocks": false,
+  "log-level": "info",
+  "source-subnets": [
+    {
+      "subnet-id": "11111111111111111111111111111111LpoYY",
+      "blockchain-id": "yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp",
+      "vm": "evm",
+      "rpc-endpoint": "https://api.avax-test.network/ext/bc/C/rpc",
+      "ws-endpoint": "wss://api.avax-test.network/ext/bc/C/ws",
+      "encrypt-connection": true,
+      "message-contracts": {
+        "0x1CEfA23287eB4aa3012AEB8A0cdF240919a2C237": {
+          "message-format": "teleporter",
+          "settings": {
+            "reward-address": "0x5072..."
           }
         }
       }
-    ],
-    "destination-subnets": [
-      {
-        "subnet-id": "7WtoAMPhrmh5KosDUsFL9yTcvw7YSxiKHPpdfs4JsgW47oZT5",
-        "blockchain-id": "2D8RG4UpSXbPbvPCAWppNJyqTG2i2CAXSkTgmTBBvs7GKNZjsY",
-        "vm":"evm",
-        "rpc-endpoint": "https://subnets.avax.network/dispatch/testnet/rpc",
-        "encrypt-connection": false,
-        "account-private-key": "0x7493dde55051a1eb6c53b01795f97838a074e3ff640c35f199092a2fb70f2ba0"
-      }
-    ]
-  }
+    }
+  ],
+  "destination-subnets": [
+    {
+      "subnet-id": "7WtoAMPhrmh5KosDUsFL9yTcvw7YSxiKHPpdfs4JsgW47oZT5",
+      "blockchain-id": "2D8RG4UpSXbPbvPCAWppNJyqTG2i2CAXSkTgmTBBvs7GKNZjsY",
+      "vm":"evm",
+      "rpc-endpoint": "https://subnets.avax.network/dispatch/testnet/rpc",
+      "encrypt-connection": true,
+      "account-private-key": "0x7493..."
+    }
+  ]
+}

--- a/sample-relayer-config.json
+++ b/sample-relayer-config.json
@@ -1,6 +1,6 @@
 {
     "network-id": 1337,
-    "p-chain-api-url": "https://api.avax-test.network/ext/bc/P",
+    "p-chain-api-url": "https://api.avax-test.network",
     "encrypt-connection": false,
     "process-missed-blocks": false,
     "source-subnets": [
@@ -14,7 +14,7 @@
           "0x1CEfA23287eB4aa3012AEB8A0cdF240919a2C237": {
             "message-format": "teleporter",
             "settings": {
-              "reward-address": "0x3f86Db..."
+              "reward-address": "0x5072b3Df8BD18eaB581e193Ba4d32573C1cB1079"
             }
           }
         }
@@ -27,7 +27,7 @@
         "vm":"evm",
         "rpc-endpoint": "https://subnets.avax.network/dispatch/testnet/rpc",
         "encrypt-connection": false,
-        "account-private-key": "0x79987..."
+        "account-private-key": "0x7493dde55051a1eb6c53b01795f97838a074e3ff640c35f199092a2fb70f2ba0"
       }
     ]
   }

--- a/sample-relayer-config.json
+++ b/sample-relayer-config.json
@@ -5,7 +5,6 @@
     {
       "subnet-id": "11111111111111111111111111111111LpoYY",
       "blockchain-id": "yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp",
-      "start-block-height": ...,
       "vm": "evm",
       "rpc-endpoint": "https://api.avax-test.network/ext/bc/C/rpc",
       "ws-endpoint": "wss://api.avax-test.network/ext/bc/C/ws",


### PR DESCRIPTION
## Why this should be merged
Make the awm-relayer easily accessible to a wider range of developers independent of their operating system and system setup. 

## How this works
By leveraging [devcontainers](https://code.visualstudio.com/docs/devcontainers/containers) the developers can open the repository either in a [Codespace](https://github.com/features/codespaces) or locally in a docker container.

## How this was tested
Manually

## How is this documented
Added a note to the readme