### PR TITLE
fix: correct supported-destinations option description

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
   `"supported-destinations": []string`
 
-  - List of destination subnet IDs that the source subnet supports. If empty, then all destinations are supported.
+  - List of destination blockchain IDs that the source blockchain supports. If empty, then all destinations are supported.
 
   `"start-block-height": unsigned integer`
 


### PR DESCRIPTION
## Why this should be merged

The description of the `supported-destinations` configuration option is wrong. See how the option is used:

https://github.com/ava-labs/awm-relayer/blob/9eb28ffcfac2bf690bb74be50463d93c0380c6ac/config/config.go#L447-L458

## How this works

Fixes the description

## How this was tested

NA

## How is this documented

NA