### PR TITLE
add api node to network if it is a validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ See the [Building](#building) section for instructions on how to build the relay
     - platform.getHeight
     - platform.validatedBy
     - platform.getValidatorsAt OR platform.getCurrentValidators
+  - If the P-Chain API node is also a subnet validator, it must have enabled:
+    - info.getNodeID
+    - info.getNodeIP
 
 ## Usage
 

--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -254,7 +254,7 @@ func (n *AppRequestNetwork) ConnectPeers(nodeIDs set.Set[ids.NodeID]) (set.Set[i
 					zap.String("nodeIP", apiNodeIP),
 					zap.Error(err),
 				)
-				retErr = fmt.Errorf("failed to parse api Node IP: %v", err)
+				retErr = fmt.Errorf("failed to parse API Node IP: %v", err)
 			} else {
 				trackedNodes.Add(apiNodeID)
 				n.Network.ManuallyTrack(apiNodeID, ipPort)

--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -244,7 +244,7 @@ func (n *AppRequestNetwork) ConnectPeers(nodeIDs set.Set[ids.NodeID]) (set.Set[i
 		} else if nodeIDs.Contains(apiNodeID) {
 			if apiNodeIP, err := n.infoClient.GetNodeIP(context.Background()); err != nil {
 				n.logger.Error(
-					"Failed to get api Node IP",
+					"Failed to get API Node IP",
 					zap.Error(err),
 				)
 				retErr = fmt.Errorf("failed to get api Node IP: %v", err)

--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -237,7 +237,7 @@ func (n *AppRequestNetwork) ConnectPeers(nodeIDs set.Set[ids.NodeID]) (set.Set[i
 		// attempt adding api node in case it is a validator
 		if apiNodeID, _, err := n.infoClient.GetNodeID(context.Background()); err != nil {
 			n.logger.Error(
-				"Failed to get api Node ID",
+				"Failed to get API Node ID",
 				zap.Error(err),
 			)
 			retErr = fmt.Errorf("failed to get api Node ID: %v", err)

--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -228,37 +228,35 @@ func (n *AppRequestNetwork) ConnectPeers(nodeIDs set.Set[ids.NodeID]) (set.Set[i
 			trackedNodes.Add(peer.ID)
 			n.Network.ManuallyTrack(peer.ID, ipPort)
 			if len(trackedNodes) == nodeIDs.Len() {
-				break
+				return trackedNodes, retErr
 			}
 		}
 	}
 
-	if len(trackedNodes) < nodeIDs.Len() {
-		// attempt adding api node in case it is a validator
-		if apiNodeID, _, err := n.infoClient.GetNodeID(context.Background()); err != nil {
+	// attempt adding api node in case it is a validator
+	if apiNodeID, _, err := n.infoClient.GetNodeID(context.Background()); err != nil {
+		n.logger.Error(
+			"Failed to get API Node ID",
+			zap.Error(err),
+		)
+		retErr = fmt.Errorf("failed to get api Node ID: %v", err)
+	} else if nodeIDs.Contains(apiNodeID) {
+		if apiNodeIP, err := n.infoClient.GetNodeIP(context.Background()); err != nil {
 			n.logger.Error(
-				"Failed to get API Node ID",
+				"Failed to get API Node IP",
 				zap.Error(err),
 			)
-			retErr = fmt.Errorf("failed to get api Node ID: %v", err)
-		} else if nodeIDs.Contains(apiNodeID) {
-			if apiNodeIP, err := n.infoClient.GetNodeIP(context.Background()); err != nil {
-				n.logger.Error(
-					"Failed to get API Node IP",
-					zap.Error(err),
-				)
-				retErr = fmt.Errorf("failed to get api Node IP: %v", err)
-			} else if ipPort, err := ips.ToIPPort(apiNodeIP); err != nil {
-				n.logger.Error(
-					"Failed to parse API Node IP",
-					zap.String("nodeIP", apiNodeIP),
-					zap.Error(err),
-				)
-				retErr = fmt.Errorf("failed to parse API Node IP: %v", err)
-			} else {
-				trackedNodes.Add(apiNodeID)
-				n.Network.ManuallyTrack(apiNodeID, ipPort)
-			}
+			retErr = fmt.Errorf("failed to get api Node IP: %v", err)
+		} else if ipPort, err := ips.ToIPPort(apiNodeIP); err != nil {
+			n.logger.Error(
+				"Failed to parse API Node IP",
+				zap.String("nodeIP", apiNodeIP),
+				zap.Error(err),
+			)
+			retErr = fmt.Errorf("failed to parse API Node IP: %v", err)
+		} else {
+			trackedNodes.Add(apiNodeID)
+			n.Network.ManuallyTrack(apiNodeID, ipPort)
 		}
 	}
 

--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -202,6 +202,40 @@ func (n *AppRequestNetwork) ConnectPeers(nodeIDs set.Set[ids.NodeID]) (set.Set[i
 	// through connectedPeers for already tracked peers, just iterate through the full list,
 	// re-adding connections to already tracked peers.
 
+	// add api node in case it is a validator
+	apiNodeID, _, err := n.infoClient.GetNodeID(context.Background())
+	if err != nil {
+		n.logger.Error(
+			"Failed to get api Node ID",
+			zap.Error(err),
+		)
+		return nil, err
+	}
+	if nodeIDs.Contains(apiNodeID) {
+		apiNodeIP, err := n.infoClient.GetNodeIP(context.Background())
+		if err != nil {
+			n.logger.Error(
+				"Failed to get api Node IP",
+				zap.Error(err),
+			)
+			return nil, err
+		}
+		ipPort, err := ips.ToIPPort(apiNodeIP)
+		if err != nil {
+			n.logger.Error(
+				"Failed to parse api Node IP",
+				zap.String("nodeIP", apiNodeIP),
+				zap.Error(err),
+			)
+			return nil, err
+		}
+		trackedNodes.Add(apiNodeID)
+		n.Network.ManuallyTrack(apiNodeID, ipPort)
+		if nodeIDs.Len() == 1 {
+			return nodeIDs, nil
+		}
+	}
+
 	// Get the list of peers
 	peers, err := n.infoClient.Peers(context.Background())
 	if err != nil {

--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -250,7 +250,7 @@ func (n *AppRequestNetwork) ConnectPeers(nodeIDs set.Set[ids.NodeID]) (set.Set[i
 				retErr = fmt.Errorf("failed to get api Node IP: %v", err)
 			} else if ipPort, err := ips.ToIPPort(apiNodeIP); err != nil {
 				n.logger.Error(
-					"Failed to parse api Node IP",
+					"Failed to parse API Node IP",
 					zap.String("nodeIP", apiNodeIP),
 					zap.Error(err),
 				)


### PR DESCRIPTION
## Why this should be merged
When the so called API node is inside the validator set for the source blockchain, it is not added itself as it is not a peer of himself (only peers to API node are added). In situations were that validator is needed to fully sign a msg, teleporter can't proceed beyond relayer step. 

## How this works
The API node adds himself is belonging to the validators set

## How this was tested
It was tested on teleporter deploys on fuji for subnets of only one validator.

## How is this documented