### PR TITLE
Rename subnet -> blockchain in Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
   - The address of the destination account that will receive the Warp message.
 
-`"source-subnets": []SourceSubnets`
+`"source-blockchains": []SourceBlockchains`
 
-- The list of source subnets to support. Each `SourceSubnet` has the following configuration:
+- The list of source subnets to support. Each `SourceBlockchain` has the following configuration:
 
   `"subnet-id": string`
 
@@ -175,9 +175,9 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
   - The block height at which to back-process transactions from the source subnet. If the database already contains a later block height for the source subnet, then that will be used instead. Must be non-zero.
 
-`"destination-subnets": []DestinationSubnets`
+`"destination-blockchains": []DestinationBlockchains`
 
-- The list of destination subnets to support. Each `DestinationSubnet` has the following configuration:
+- The list of destination subnets to support. Each `DestinationBlockchain` has the following configuration:
 
   `"subnet-id": string`
 

--- a/config/keys.go
+++ b/config/keys.go
@@ -5,14 +5,14 @@ package config
 
 // Top-level configuration keys
 const (
-	ConfigFileKey          = "config-file"
-	LogLevelKey            = "log-level"
-	PChainAPIURLKey        = "p-chain-api-url"
-	InfoAPIURLKey          = "info-api-url"
-	SourceSubnetsKey       = "source-subnets"
-	DestinationSubnetsKey  = "destination-subnets"
-	AccountPrivateKeyKey   = "account-private-key"
-	StorageLocationKey     = "storage-location"
-	ProcessMissedBlocksKey = "process-missed-blocks"
-	ManualWarpMessagesKey  = "manual-warp-messages"
+	ConfigFileKey             = "config-file"
+	LogLevelKey               = "log-level"
+	PChainAPIURLKey           = "p-chain-api-url"
+	InfoAPIURLKey             = "info-api-url"
+	SourceBlockchainsKey      = "source-blockchains"
+	DestinationBlockchainsKey = "destination-blockchains"
+	AccountPrivateKeyKey      = "account-private-key"
+	StorageLocationKey        = "storage-location"
+	ProcessMissedBlocksKey    = "process-missed-blocks"
+	ManualWarpMessagesKey     = "manual-warp-messages"
 )

--- a/main/main.go
+++ b/main/main.go
@@ -189,7 +189,7 @@ func main() {
 
 	// Create relayers for each of the subnets configured as a source
 	errGroup, ctx := errgroup.WithContext(context.Background())
-	for _, s := range cfg.SourceSubnets {
+	for _, s := range cfg.SourceBlockchains {
 		blockchainID, err := ids.FromString(s.BlockchainID)
 		if err != nil {
 			logger.Error(
@@ -236,7 +236,7 @@ func runRelayer(
 	logger logging.Logger,
 	metrics *relayer.MessageRelayerMetrics,
 	db database.RelayerDatabase,
-	sourceSubnetInfo config.SourceSubnet,
+	sourceSubnetInfo config.SourceBlockchain,
 	pChainClient platformvm.Client,
 	network *peers.AppRequestNetwork,
 	responseChan chan message.InboundMessage,

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -68,7 +68,7 @@ func NewRelayer(
 	logger logging.Logger,
 	metrics *MessageRelayerMetrics,
 	db database.RelayerDatabase,
-	sourceSubnetInfo config.SourceSubnet,
+	sourceSubnetInfo config.SourceBlockchain,
 	pChainClient platformvm.Client,
 	network *peers.AppRequestNetwork,
 	responseChan chan message.InboundMessage,

--- a/tests/basic_relay.go
+++ b/tests/basic_relay.go
@@ -163,7 +163,7 @@ func BasicRelay(network interfaces.LocalNetwork) {
 	// StartBlockHeight to the block height of the *third* message, we expect the relayer to skip
 	// the first two messages on startup, but process the third.
 	modifiedRelayerConfig := relayerConfig
-	modifiedRelayerConfig.SourceSubnets[0].StartBlockHeight = currHeight
+	modifiedRelayerConfig.SourceBlockchains[0].StartBlockHeight = currHeight
 	modifiedRelayerConfig.ProcessMissedBlocks = true
 	relayerConfigPath = writeRelayerConfig(modifiedRelayerConfig)
 

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -94,13 +94,13 @@ func CreateDefaultRelayerConfig(
 		"Setting up relayer config",
 	)
 	// Construct the config values for each subnet
-	sources := make([]*config.SourceSubnet, len(subnetsInfo))
-	destinations := make([]*config.DestinationSubnet, len(subnetsInfo))
+	sources := make([]*config.SourceBlockchain, len(subnetsInfo))
+	destinations := make([]*config.DestinationBlockchain, len(subnetsInfo))
 	for i, subnetInfo := range subnetsInfo {
 		host, port, err := teleporterTestUtils.GetURIHostAndPort(subnetInfo.NodeURIs[0])
 		Expect(err).Should(BeNil())
 
-		sources[i] = &config.SourceSubnet{
+		sources[i] = &config.SourceBlockchain{
 			SubnetID:     subnetInfo.SubnetID.String(),
 			BlockchainID: subnetInfo.BlockchainID.String(),
 			VM:           config.EVM.String(),
@@ -123,7 +123,7 @@ func CreateDefaultRelayerConfig(
 			},
 		}
 
-		destinations[i] = &config.DestinationSubnet{
+		destinations[i] = &config.DestinationBlockchain{
 			SubnetID:          subnetInfo.SubnetID.String(),
 			BlockchainID:      subnetInfo.BlockchainID.String(),
 			VM:                config.EVM.String(),
@@ -141,13 +141,13 @@ func CreateDefaultRelayerConfig(
 	}
 
 	return config.Config{
-		LogLevel:            logging.Info.LowerString(),
-		PChainAPIURL:        subnetsInfo[0].NodeURIs[0],
-		InfoAPIURL:          subnetsInfo[0].NodeURIs[0],
-		StorageLocation:     RelayerStorageLocation(),
-		ProcessMissedBlocks: false,
-		SourceSubnets:       sources,
-		DestinationSubnets:  destinations,
+		LogLevel:               logging.Info.LowerString(),
+		PChainAPIURL:           subnetsInfo[0].NodeURIs[0],
+		InfoAPIURL:             subnetsInfo[0].NodeURIs[0],
+		StorageLocation:        RelayerStorageLocation(),
+		ProcessMissedBlocks:    false,
+		SourceBlockchains:      sources,
+		DestinationBlockchains: destinations,
 	}
 }
 

--- a/vms/contract_message.go
+++ b/vms/contract_message.go
@@ -15,7 +15,7 @@ type ContractMessage interface {
 	UnpackWarpMessage(unsignedMsgBytes []byte) (*warp.UnsignedMessage, error)
 }
 
-func NewContractMessage(logger logging.Logger, subnetInfo config.SourceSubnet) ContractMessage {
+func NewContractMessage(logger logging.Logger, subnetInfo config.SourceBlockchain) ContractMessage {
 	switch config.ParseVM(subnetInfo.VM) {
 	case config.EVM:
 		return evm.NewContractMessage(logger, subnetInfo)

--- a/vms/destination_client.go
+++ b/vms/destination_client.go
@@ -34,7 +34,7 @@ type DestinationClient interface {
 	DestinationBlockchainID() ids.ID
 }
 
-func NewDestinationClient(logger logging.Logger, subnetInfo config.DestinationSubnet) (DestinationClient, error) {
+func NewDestinationClient(logger logging.Logger, subnetInfo config.DestinationBlockchain) (DestinationClient, error) {
 	switch config.ParseVM(subnetInfo.VM) {
 	case config.EVM:
 		return evm.NewDestinationClient(logger, subnetInfo)
@@ -46,7 +46,7 @@ func NewDestinationClient(logger logging.Logger, subnetInfo config.DestinationSu
 // CreateDestinationClients creates destination clients for all subnets configured as destinations
 func CreateDestinationClients(logger logging.Logger, relayerConfig config.Config) (map[ids.ID]DestinationClient, error) {
 	destinationClients := make(map[ids.ID]DestinationClient)
-	for _, subnetInfo := range relayerConfig.DestinationSubnets {
+	for _, subnetInfo := range relayerConfig.DestinationBlockchains {
 		blockchainID, err := ids.FromString(subnetInfo.BlockchainID)
 		if err != nil {
 			logger.Error(

--- a/vms/evm/contract_message.go
+++ b/vms/evm/contract_message.go
@@ -17,7 +17,7 @@ type contractMessage struct {
 	logger logging.Logger
 }
 
-func NewContractMessage(logger logging.Logger, subnetInfo config.SourceSubnet) *contractMessage {
+func NewContractMessage(logger logging.Logger, subnetInfo config.SourceBlockchain) *contractMessage {
 	return &contractMessage{
 		logger: logger,
 	}

--- a/vms/evm/contract_message_test.go
+++ b/vms/evm/contract_message_test.go
@@ -51,7 +51,7 @@ func TestUnpack(t *testing.T) {
 			logging.JSON.ConsoleEncoder(),
 		),
 	)
-	m := NewContractMessage(logger, config.SourceSubnet{})
+	m := NewContractMessage(logger, config.SourceBlockchain{})
 
 	testCases := []struct {
 		name        string

--- a/vms/evm/destination_client.go
+++ b/vms/evm/destination_client.go
@@ -48,7 +48,7 @@ type destinationClient struct {
 	logger                  logging.Logger
 }
 
-func NewDestinationClient(logger logging.Logger, subnetInfo config.DestinationSubnet) (*destinationClient, error) {
+func NewDestinationClient(logger logging.Logger, subnetInfo config.DestinationBlockchain) (*destinationClient, error) {
 	// Dial the destination RPC endpoint
 	client, err := ethclient.Dial(subnetInfo.RPCEndpoint)
 	if err != nil {

--- a/vms/evm/destination_client_test.go
+++ b/vms/evm/destination_client_test.go
@@ -17,7 +17,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-var destinationSubnet = config.DestinationSubnet{
+var destinationSubnet = config.DestinationBlockchain{
 	SubnetID:          "2TGBXcnwx5PqiXWiqxAKUaNSqDguXNh1mxnp82jui68hxJSZAx",
 	BlockchainID:      "S4mMqUXe7vHsGiRAma6bv3CKnyaLssyAxmQ2KvFpX1KEvfFCD",
 	VM:                config.EVM.String(),

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -61,7 +61,7 @@ type subscriber struct {
 }
 
 // NewSubscriber returns a subscriber
-func NewSubscriber(logger logging.Logger, subnetInfo config.SourceSubnet) *subscriber {
+func NewSubscriber(logger logging.Logger, subnetInfo config.SourceBlockchain) *subscriber {
 	blockchainID, err := ids.FromString(subnetInfo.BlockchainID)
 	if err != nil {
 		logger.Error(

--- a/vms/evm/subscriber_test.go
+++ b/vms/evm/subscriber_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func makeSubscriberWithMockEthClient(t *testing.T) (*subscriber, *mock_ethclient.MockClient) {
-	sourceSubnet := config.SourceSubnet{
+	sourceSubnet := config.SourceBlockchain{
 		SubnetID:     "2TGBXcnwx5PqiXWiqxAKUaNSqDguXNh1mxnp82jui68hxJSZAx",
 		BlockchainID: "S4mMqUXe7vHsGiRAma6bv3CKnyaLssyAxmQ2KvFpX1KEvfFCD",
 		VM:           config.EVM.String(),

--- a/vms/subscriber.go
+++ b/vms/subscriber.go
@@ -37,7 +37,7 @@ type Subscriber interface {
 }
 
 // NewSubscriber returns a concrete Subscriber according to the VM specified by [subnetInfo]
-func NewSubscriber(logger logging.Logger, subnetInfo config.SourceSubnet) Subscriber {
+func NewSubscriber(logger logging.Logger, subnetInfo config.SourceBlockchain) Subscriber {
 	switch config.ParseVM(subnetInfo.VM) {
 	case config.EVM:
 		return evm.NewSubscriber(logger, subnetInfo)


### PR DESCRIPTION
## Why this should be merged
Fixes #170 

The application requires unique Blockchain IDs in the configuration, but the naming suggests that Subnets also need to be unique. Subnets can contain multiple blockchains, in which case there would need to be multiple entries in `SourceSubnets` and `DestinationSubnets` with the same subnet ID.

## How this works
Renames `SourceSubnet` to `SourceBlockchain` and `DestinationSubnet` to `DestinationBlockchain` in the configuration.

## How this was tested
CI

## How is this documented
Updated README