### PR TITLE
Check connected peer weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@ See the [Building](#building) section for instructions on how to build the relay
   - Each subnet API node must have enabled:
     - eth API (RPC and WS)
   - The P-Chain API node must have enabled:
-    - info.peers
     - platform.getHeight
     - platform.validatedBy
     - platform.getValidatorsAt OR platform.getCurrentValidators
-  - If the P-Chain API node is also a subnet validator, it must have enabled:
+  - The Info API node must have enabled:
+    - info.peers
+    - info.getNetworkID
+  - If the Info API node is also a subnet validator, it must have enabled:
     - info.getNodeID
     - info.getNodeIP
 
@@ -104,13 +106,17 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 - The URL of the Avalanche P-Chain API node to which the relayer will connect. This API node needs to have the following methods enabled:
   - platform.getHeight
   - platform.validatedBy
-  - platform.getValidatorsAt
+  - platform.getValidatorsAt OR platform.getCurrentValidators
 
 `"info-api-url": string`
 
 - The URL of the Avalanche Info API node to which the relayer will connect. This API node needs to have the following methods enabled:
   - info.peers
   - info.getNetworkID
+
+- Additionally, if the Info API node is also a validator, it must have enabled:
+  - info.getNodeID
+  - info.getNodeIP
 
 `"storage-location": string`
 

--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -183,21 +183,15 @@ func NewNetwork(
 }
 
 // ConnectPeers connects the network to peers with the given nodeIDs.
-// On success, returns the provided set of nodeIDs and a nil error.
-// On failure, returns the set of nodeIDs that successfully connected and an error.
-func (n *AppRequestNetwork) ConnectPeers(nodeIDs set.Set[ids.NodeID]) (set.Set[ids.NodeID], error) {
+// Returns the set of nodeIDs that were successfully connected to.
+func (n *AppRequestNetwork) ConnectPeers(nodeIDs set.Set[ids.NodeID]) set.Set[ids.NodeID] {
 	n.lock.Lock()
 	defer n.lock.Unlock()
-
-	var (
-		retErr       error
-		trackedNodes set.Set[ids.NodeID]
-	)
 
 	// First, check if we are already connected to all the peers
 	connectedPeers := n.Network.PeerInfo(nodeIDs.List())
 	if len(connectedPeers) == nodeIDs.Len() {
-		return nodeIDs, nil
+		return nodeIDs
 	}
 
 	// If we are not connected to all the peers already, then we have to iterate
@@ -212,10 +206,11 @@ func (n *AppRequestNetwork) ConnectPeers(nodeIDs set.Set[ids.NodeID]) (set.Set[i
 			"Failed to get peers",
 			zap.Error(err),
 		)
-		return nil, err
+		return nil
 	}
 
 	// Attempt to connect to each peer
+	var trackedNodes set.Set[ids.NodeID]
 	for _, peer := range peers {
 		if nodeIDs.Contains(peer.ID) {
 			ipPort, err := ips.ToIPPort(peer.PublicIP)
@@ -225,43 +220,39 @@ func (n *AppRequestNetwork) ConnectPeers(nodeIDs set.Set[ids.NodeID]) (set.Set[i
 					zap.String("beaconIP", peer.PublicIP),
 					zap.Error(err),
 				)
-				retErr = fmt.Errorf("failed to connect to peers: %v", err)
 				continue
 			}
 			trackedNodes.Add(peer.ID)
 			n.Network.ManuallyTrack(peer.ID, ipPort)
 			if len(trackedNodes) == nodeIDs.Len() {
-				return trackedNodes, retErr
+				return trackedNodes
 			}
 		}
 	}
 
-	// attempt adding api node in case it is a validator
+	// If we haven't yet connected to all peers, attempt to connect to the API node in case it is a validator
 	if apiNodeID, _, err := n.infoClient.GetNodeID(context.Background()); err != nil {
 		n.logger.Error(
 			"Failed to get API Node ID",
 			zap.Error(err),
 		)
-		retErr = fmt.Errorf("failed to get api Node ID: %v", err)
 	} else if nodeIDs.Contains(apiNodeID) {
 		if apiNodeIP, err := n.infoClient.GetNodeIP(context.Background()); err != nil {
 			n.logger.Error(
 				"Failed to get API Node IP",
 				zap.Error(err),
 			)
-			retErr = fmt.Errorf("failed to get api Node IP: %v", err)
 		} else if ipPort, err := ips.ToIPPort(apiNodeIP); err != nil {
 			n.logger.Error(
 				"Failed to parse API Node IP",
 				zap.String("nodeIP", apiNodeIP),
 				zap.Error(err),
 			)
-			retErr = fmt.Errorf("failed to parse API Node IP: %v", err)
 		} else {
 			trackedNodes.Add(apiNodeID)
 			n.Network.ManuallyTrack(apiNodeID, ipPort)
 		}
 	}
 
-	return trackedNodes, retErr
+	return trackedNodes
 }


### PR DESCRIPTION
## Why this should be merged
Currently, we abandon message relaying if we fail to connect to any of the subnet validators. However, the aggregate signature only needs a quorum of stake weight to be valid, so this constraint is overly restrictive.

This change relaxes that constraint by attempting to connect to all peers, then comparing the total connected stake against the quorum value of the destination blockchain.

## How this works
`AppRequestNetwork.ConnectPeers` returns the set of connected peers, and no error. It is up to the caller to determine if the returned value constitutes an error. The message relayer uses the connected stake to determine whether or not to proceed with relaying.

## How this was tested
CI

## How is this documented
N/A