### PR TITLE
Remove default for process-missed-blocks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,9 +31,7 @@ const (
 	warpConfigKey               = "warpConfig"
 )
 
-var (
-	errFailedToGetWarpQuorum = errors.New("failed to get warp quorum")
-)
+var errFailedToGetWarpQuorum = errors.New("failed to get warp quorum")
 
 type MessageProtocolConfig struct {
 	MessageFormat string                 `mapstructure:"message-format" json:"message-format"`
@@ -103,7 +101,6 @@ type Config struct {
 func SetDefaultConfigValues(v *viper.Viper) {
 	v.SetDefault(LogLevelKey, logging.Info.String())
 	v.SetDefault(StorageLocationKey, "./.awm-relayer-storage")
-	v.SetDefault(ProcessMissedBlocksKey, true)
 }
 
 // BuildConfig constructs the relayer config using Viper.
@@ -248,15 +245,19 @@ func (c *Config) Validate() error {
 func (m *ManualWarpMessage) GetUnsignedMessageBytes() []byte {
 	return m.unsignedMessageBytes
 }
+
 func (m *ManualWarpMessage) GetSourceBlockchainID() ids.ID {
 	return m.sourceBlockchainID
 }
+
 func (m *ManualWarpMessage) GetSourceAddress() common.Address {
 	return m.sourceAddress
 }
+
 func (m *ManualWarpMessage) GetDestinationBlockchainID() ids.ID {
 	return m.destinationBlockchainID
 }
+
 func (m *ManualWarpMessage) GetDestinationAddress() common.Address {
 	return m.destinationAddress
 }


### PR DESCRIPTION
## Why this should be merged
Removes default of `true` for `process-missed-blocks` to align with documentation.

We want this to be `false` by default, because it will cause the default behaviour for the relayer to be to start from the chain head. Currently this is causing an error unless the user either manually sets `process-missed-blocks` to `false`, or sets `start-block-height`.