### PR TITLE
Simplify options for process-historical-blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,9 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
 - The path to the directory in which the relayer will store its state. Defaults to `./awm-relayer-storage`.
 
-`"process-historical-blocks": boolean`
-
-- Whether or not to process missed blocks on first startup. Defaults to `false`. If set to true, `start-block-height` must also be set to a non-zero value.
-
 `"process-missed-blocks": boolean`
 
-- Whether or not to process missed blocks after restarting. Defaults to `true`.
+- Whether or not to process missed blocks after restarting. Defaults to `true`. If set to false, the relayer will start processing blocks from the chain head.
 
 `"manual-warp-messages": []ManualWarpMessage`
 
@@ -188,7 +184,7 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
   - List of destination blockchain IDs that the source blockchain supports. If empty, then all destinations are supported.
 
-  `"start-block-height": unsigned integer`
+  `"process-historical-blocks-from-height": unsigned integer`
 
   - The block height at which to back-process transactions from the source subnet. If the database already contains a later block height for the source subnet, then that will be used instead. Must be non-zero.
 

--- a/README.md
+++ b/README.md
@@ -116,9 +116,13 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
 - The path to the directory in which the relayer will store its state. Defaults to `./awm-relayer-storage`.
 
+`"process-historical-blocks": boolean`
+
+- Whether or not to process missed blocks on first startup. Defaults to `false`. If set to true, `start-block-height` must also be set to a non-zero value.
+
 `"process-missed-blocks": boolean`
 
-- Whether or not to process missed blocks on startup. Defaults to `false`.
+- Whether or not to process missed blocks after restarting. Defaults to `true`.
 
 `"manual-warp-messages": []ManualWarpMessage`
 

--- a/config/config.go
+++ b/config/config.go
@@ -54,14 +54,14 @@ type ManualWarpMessage struct {
 }
 
 type SourceBlockchain struct {
-	SubnetID              string                           `mapstructure:"subnet-id" json:"subnet-id"`
-	BlockchainID          string                           `mapstructure:"blockchain-id" json:"blockchain-id"`
-	VM                    string                           `mapstructure:"vm" json:"vm"`
-	RPCEndpoint           string                           `mapstructure:"rpc-endpoint" json:"rpc-endpoint"`
-	WSEndpoint            string                           `mapstructure:"ws-endpoint" json:"ws-endpoint"`
-	MessageContracts      map[string]MessageProtocolConfig `mapstructure:"message-contracts" json:"message-contracts"`
-	SupportedDestinations []string                         `mapstructure:"supported-destinations" json:"supported-destinations"`
-	StartBlockHeight      uint64                           `mapstructure:"process-historical-blocks-from-height" json:"process-historical-blocks-from-height"`
+	SubnetID                          string                           `mapstructure:"subnet-id" json:"subnet-id"`
+	BlockchainID                      string                           `mapstructure:"blockchain-id" json:"blockchain-id"`
+	VM                                string                           `mapstructure:"vm" json:"vm"`
+	RPCEndpoint                       string                           `mapstructure:"rpc-endpoint" json:"rpc-endpoint"`
+	WSEndpoint                        string                           `mapstructure:"ws-endpoint" json:"ws-endpoint"`
+	MessageContracts                  map[string]MessageProtocolConfig `mapstructure:"message-contracts" json:"message-contracts"`
+	SupportedDestinations             []string                         `mapstructure:"supported-destinations" json:"supported-destinations"`
+	ProcessHistoricalBlocksFromHeight uint64                           `mapstructure:"process-historical-blocks-from-height" json:"process-historical-blocks-from-height"`
 
 	// convenience field to access the supported destinations after initialization
 	supportedDestinations set.Set[ids.ID]

--- a/config/config.go
+++ b/config/config.go
@@ -31,9 +31,7 @@ const (
 	warpConfigKey               = "warpConfig"
 )
 
-var (
-	errFailedToGetWarpQuorum = errors.New("failed to get warp quorum")
-)
+var errFailedToGetWarpQuorum = errors.New("failed to get warp quorum")
 
 type MessageProtocolConfig struct {
 	MessageFormat string                 `mapstructure:"message-format" json:"message-format"`
@@ -86,14 +84,15 @@ type WarpQuorum struct {
 }
 
 type Config struct {
-	LogLevel               string                   `mapstructure:"log-level" json:"log-level"`
-	PChainAPIURL           string                   `mapstructure:"p-chain-api-url" json:"p-chain-api-url"`
-	InfoAPIURL             string                   `mapstructure:"info-api-url" json:"info-api-url"`
-	StorageLocation        string                   `mapstructure:"storage-location" json:"storage-location"`
-	SourceBlockchains      []*SourceBlockchain      `mapstructure:"source-blockchains" json:"source-blockchains"`
-	DestinationBlockchains []*DestinationBlockchain `mapstructure:"destination-blockchains" json:"destination-blockchains"`
-	ProcessMissedBlocks    bool                     `mapstructure:"process-missed-blocks" json:"process-missed-blocks"`
-	ManualWarpMessages     []*ManualWarpMessage     `mapstructure:"manual-warp-messages" json:"manual-warp-messages"`
+	LogLevel                string                   `mapstructure:"log-level" json:"log-level"`
+	PChainAPIURL            string                   `mapstructure:"p-chain-api-url" json:"p-chain-api-url"`
+	InfoAPIURL              string                   `mapstructure:"info-api-url" json:"info-api-url"`
+	StorageLocation         string                   `mapstructure:"storage-location" json:"storage-location"`
+	SourceBlockchains       []*SourceBlockchain      `mapstructure:"source-blockchains" json:"source-blockchains"`
+	DestinationBlockchains  []*DestinationBlockchain `mapstructure:"destination-blockchains" json:"destination-blockchains"`
+	ProcessHistoricalBlocks bool                     `mapstructure:"process-historical-blocks" json:"process-historical-blocks"`
+	ProcessMissedBlocks     bool                     `mapstructure:"process-missed-blocks" json:"process-missed-blocks"`
+	ManualWarpMessages      []*ManualWarpMessage     `mapstructure:"manual-warp-messages" json:"manual-warp-messages"`
 
 	// convenience fields to access the source subnet and chain IDs after initialization
 	sourceSubnetIDs     []ids.ID
@@ -248,15 +247,19 @@ func (c *Config) Validate() error {
 func (m *ManualWarpMessage) GetUnsignedMessageBytes() []byte {
 	return m.unsignedMessageBytes
 }
+
 func (m *ManualWarpMessage) GetSourceBlockchainID() ids.ID {
 	return m.sourceBlockchainID
 }
+
 func (m *ManualWarpMessage) GetSourceAddress() common.Address {
 	return m.sourceAddress
 }
+
 func (m *ManualWarpMessage) GetDestinationBlockchainID() ids.ID {
 	return m.destinationBlockchainID
 }
+
 func (m *ManualWarpMessage) GetDestinationAddress() common.Address {
 	return m.destinationAddress
 }

--- a/config/config.go
+++ b/config/config.go
@@ -61,7 +61,7 @@ type SourceBlockchain struct {
 	WSEndpoint            string                           `mapstructure:"ws-endpoint" json:"ws-endpoint"`
 	MessageContracts      map[string]MessageProtocolConfig `mapstructure:"message-contracts" json:"message-contracts"`
 	SupportedDestinations []string                         `mapstructure:"supported-destinations" json:"supported-destinations"`
-	StartBlockHeight      uint64                           `mapstructure:"start-block-height" json:"start-block-height"`
+	StartBlockHeight      uint64                           `mapstructure:"process-historical-blocks-from-height" json:"process-historical-blocks-from-height"`
 
 	// convenience field to access the supported destinations after initialization
 	supportedDestinations set.Set[ids.ID]
@@ -90,7 +90,6 @@ type Config struct {
 	StorageLocation         string                   `mapstructure:"storage-location" json:"storage-location"`
 	SourceBlockchains       []*SourceBlockchain      `mapstructure:"source-blockchains" json:"source-blockchains"`
 	DestinationBlockchains  []*DestinationBlockchain `mapstructure:"destination-blockchains" json:"destination-blockchains"`
-	ProcessHistoricalBlocks bool                     `mapstructure:"process-historical-blocks" json:"process-historical-blocks"`
 	ProcessMissedBlocks     bool                     `mapstructure:"process-missed-blocks" json:"process-missed-blocks"`
 	ManualWarpMessages      []*ManualWarpMessage     `mapstructure:"manual-warp-messages" json:"manual-warp-messages"`
 
@@ -132,7 +131,6 @@ func BuildConfig(v *viper.Viper) (Config, bool, error) {
 	cfg.InfoAPIURL = v.GetString(InfoAPIURLKey)
 	cfg.StorageLocation = v.GetString(StorageLocationKey)
 	cfg.ProcessMissedBlocks = v.GetBool(ProcessMissedBlocksKey)
-	cfg.ProcessHistoricalBlocks = v.GetBool(ProcessHistoricalBlocksKey)
 	if err := v.UnmarshalKey(ManualWarpMessagesKey, &cfg.ManualWarpMessages); err != nil {
 		return Config{}, false, fmt.Errorf("failed to unmarshal manual warp messages: %w", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -84,14 +84,14 @@ type WarpQuorum struct {
 }
 
 type Config struct {
-	LogLevel                string                   `mapstructure:"log-level" json:"log-level"`
-	PChainAPIURL            string                   `mapstructure:"p-chain-api-url" json:"p-chain-api-url"`
-	InfoAPIURL              string                   `mapstructure:"info-api-url" json:"info-api-url"`
-	StorageLocation         string                   `mapstructure:"storage-location" json:"storage-location"`
-	SourceBlockchains       []*SourceBlockchain      `mapstructure:"source-blockchains" json:"source-blockchains"`
-	DestinationBlockchains  []*DestinationBlockchain `mapstructure:"destination-blockchains" json:"destination-blockchains"`
-	ProcessMissedBlocks     bool                     `mapstructure:"process-missed-blocks" json:"process-missed-blocks"`
-	ManualWarpMessages      []*ManualWarpMessage     `mapstructure:"manual-warp-messages" json:"manual-warp-messages"`
+	LogLevel               string                   `mapstructure:"log-level" json:"log-level"`
+	PChainAPIURL           string                   `mapstructure:"p-chain-api-url" json:"p-chain-api-url"`
+	InfoAPIURL             string                   `mapstructure:"info-api-url" json:"info-api-url"`
+	StorageLocation        string                   `mapstructure:"storage-location" json:"storage-location"`
+	SourceBlockchains      []*SourceBlockchain      `mapstructure:"source-blockchains" json:"source-blockchains"`
+	DestinationBlockchains []*DestinationBlockchain `mapstructure:"destination-blockchains" json:"destination-blockchains"`
+	ProcessMissedBlocks    bool                     `mapstructure:"process-missed-blocks" json:"process-missed-blocks"`
+	ManualWarpMessages     []*ManualWarpMessage     `mapstructure:"manual-warp-messages" json:"manual-warp-messages"`
 
 	// convenience fields to access the source subnet and chain IDs after initialization
 	sourceSubnetIDs     []ids.ID

--- a/config/config.go
+++ b/config/config.go
@@ -132,6 +132,7 @@ func BuildConfig(v *viper.Viper) (Config, bool, error) {
 	cfg.InfoAPIURL = v.GetString(InfoAPIURLKey)
 	cfg.StorageLocation = v.GetString(StorageLocationKey)
 	cfg.ProcessMissedBlocks = v.GetBool(ProcessMissedBlocksKey)
+	cfg.ProcessHistoricalBlocks = v.GetBool(ProcessHistoricalBlocksKey)
 	if err := v.UnmarshalKey(ManualWarpMessagesKey, &cfg.ManualWarpMessages); err != nil {
 		return Config{}, false, fmt.Errorf("failed to unmarshal manual warp messages: %w", err)
 	}

--- a/config/keys.go
+++ b/config/keys.go
@@ -5,14 +5,15 @@ package config
 
 // Top-level configuration keys
 const (
-	ConfigFileKey             = "config-file"
-	LogLevelKey               = "log-level"
-	PChainAPIURLKey           = "p-chain-api-url"
-	InfoAPIURLKey             = "info-api-url"
-	SourceBlockchainsKey      = "source-blockchains"
-	DestinationBlockchainsKey = "destination-blockchains"
-	AccountPrivateKeyKey      = "account-private-key"
-	StorageLocationKey        = "storage-location"
-	ProcessMissedBlocksKey    = "process-missed-blocks"
-	ManualWarpMessagesKey     = "manual-warp-messages"
+	ConfigFileKey              = "config-file"
+	LogLevelKey                = "log-level"
+	PChainAPIURLKey            = "p-chain-api-url"
+	InfoAPIURLKey              = "info-api-url"
+	SourceBlockchainsKey       = "source-blockchains"
+	DestinationBlockchainsKey  = "destination-blockchains"
+	AccountPrivateKeyKey       = "account-private-key"
+	StorageLocationKey         = "storage-location"
+	ProcessHistoricalBlocksKey = "process-historical-blocks"
+	ProcessMissedBlocksKey     = "process-missed-blocks"
+	ManualWarpMessagesKey      = "manual-warp-messages"
 )

--- a/config/keys.go
+++ b/config/keys.go
@@ -5,15 +5,14 @@ package config
 
 // Top-level configuration keys
 const (
-	ConfigFileKey              = "config-file"
-	LogLevelKey                = "log-level"
-	PChainAPIURLKey            = "p-chain-api-url"
-	InfoAPIURLKey              = "info-api-url"
-	SourceBlockchainsKey       = "source-blockchains"
-	DestinationBlockchainsKey  = "destination-blockchains"
-	AccountPrivateKeyKey       = "account-private-key"
-	StorageLocationKey         = "storage-location"
-	ProcessHistoricalBlocksKey = "process-historical-blocks"
-	ProcessMissedBlocksKey     = "process-missed-blocks"
-	ManualWarpMessagesKey      = "manual-warp-messages"
+	ConfigFileKey             = "config-file"
+	LogLevelKey               = "log-level"
+	PChainAPIURLKey           = "p-chain-api-url"
+	InfoAPIURLKey             = "info-api-url"
+	SourceBlockchainsKey      = "source-blockchains"
+	DestinationBlockchainsKey = "destination-blockchains"
+	AccountPrivateKeyKey      = "account-private-key"
+	StorageLocationKey        = "storage-location"
+	ProcessMissedBlocksKey    = "process-missed-blocks"
+	ManualWarpMessagesKey     = "manual-warp-messages"
 )

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -170,7 +170,7 @@ func NewRelayer(
 		go sub.ProcessFromHeight(big.NewInt(0).SetUint64(height), r.catchUpResultChan)
 	} else {
 		r.logger.Info(
-			"processed-missed-blocks set to false, starting process from chain head",
+			"processed-missed-blocks set to false, starting processing from chain head",
 			zap.String("blockchainID", r.sourceBlockchainID.String()),
 		)
 		_, err = r.setProcessedBlockHeightToLatest()

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -176,9 +176,14 @@ func NewRelayer(
 
 	if r.globalConfig.ProcessMissedBlocks {
 		latestProcessedBlock, err := r.getLatestProcessedBlockHeight()
-		// If we found a latest processed block, process from there.
+		// If we found a latest processed block, process any missed blocks.
 		if err == nil {
-			go sub.ProcessFromHeight(big.NewInt(0).SetUint64(latestProcessedBlock), r.catchUpResultChan)
+			startBlock := latestProcessedBlock
+			// Start from the greater of StartBlockHeight and latestProcessedBlock
+			if sourceSubnetInfo.StartBlockHeight > latestProcessedBlock {
+				startBlock = sourceSubnetInfo.StartBlockHeight
+			}
+			go sub.ProcessFromHeight(big.NewInt(0).SetUint64(startBlock), r.catchUpResultChan)
 			return &r, nil
 		}
 		// This error case is okay. It will happen on the first startup if ProcessHistoricalBlocks is false.

--- a/relayer/relayer_test.go
+++ b/relayer/relayer_test.go
@@ -88,15 +88,6 @@ func TestCalculateStartingBlockHeight(t *testing.T) {
 		expectedError error
 	}{
 		{
-			// No value in cfg or db
-			name:          "no value in cfg or db",
-			cfgBlock:      0,
-			dbBlock:       0,
-			dbError:       database.ErrKeyNotFound,
-			expectedBlock: 0,
-			expectedError: ErrNoStartBlock,
-		},
-		{
 			// Value in cfg, no value in db
 			name:          "value in cfg, no value in db",
 			cfgBlock:      100,

--- a/tests/basic_relay.go
+++ b/tests/basic_relay.go
@@ -35,7 +35,7 @@ import (
 // - Relaying from Subnet A to Subnet B
 // - Relaying from Subnet B to Subnet A
 // - Relaying an already delivered message
-// - Setting StartBlockHeight in config
+// - Setting ProcessHistoricalBlocksFromHeight in config
 func BasicRelay(network interfaces.LocalNetwork) {
 	subnetAInfo := network.GetPrimaryNetworkInfo()
 	subnetBInfo, _ := utils.GetTwoSubnets(network)
@@ -144,9 +144,9 @@ func BasicRelay(network interfaces.LocalNetwork) {
 	relayerCleanup()
 
 	//
-	// Set StartBlockHeight in config
+	// Set ProcessHistoricalBlocksFromHeight in config
 	//
-	log.Info("Test Setting StartBlockHeight in config")
+	log.Info("Test Setting ProcessHistoricalBlocksFromHeight in config")
 
 	// Send three Teleporter messages from subnet A to subnet B
 	log.Info("Sending three Teleporter messages from subnet A to subnet B")
@@ -160,10 +160,10 @@ func BasicRelay(network interfaces.LocalNetwork) {
 
 	// Configure the relayer such that it will only process the last of the three messages sent above.
 	// The relayer DB stores the height of the block *before* the first message, so by setting the
-	// StartBlockHeight to the block height of the *third* message, we expect the relayer to skip
+	// ProcessHistoricalBlocksFromHeight to the block height of the *third* message, we expect the relayer to skip
 	// the first two messages on startup, but process the third.
 	modifiedRelayerConfig := relayerConfig
-	modifiedRelayerConfig.SourceBlockchains[0].StartBlockHeight = currHeight
+	modifiedRelayerConfig.SourceBlockchains[0].ProcessHistoricalBlocksFromHeight = currHeight
 	modifiedRelayerConfig.ProcessMissedBlocks = true
 	relayerConfigPath = writeRelayerConfig(modifiedRelayerConfig)
 

--- a/tests/basic_relay.go
+++ b/tests/basic_relay.go
@@ -164,8 +164,7 @@ func BasicRelay(network interfaces.LocalNetwork) {
 	// the first two messages on startup, but process the third.
 	modifiedRelayerConfig := relayerConfig
 	modifiedRelayerConfig.SourceBlockchains[0].StartBlockHeight = currHeight
-	modifiedRelayerConfig.ProcessHistoricalBlocks = true
-	modifiedRelayerConfig.ProcessMissedBlocks = false
+	modifiedRelayerConfig.ProcessMissedBlocks = true
 	relayerConfigPath = writeRelayerConfig(modifiedRelayerConfig)
 
 	log.Info("Starting the relayer")
@@ -182,59 +181,6 @@ func BasicRelay(network interfaces.LocalNetwork) {
 	)
 	Expect(err).Should(BeNil())
 	delivered3, err := subnetBInfo.TeleporterMessenger.MessageReceived(
-		&bind.CallOpts{}, id3,
-	)
-	Expect(err).Should(BeNil())
-	Expect(delivered1).Should(BeFalse())
-	Expect(delivered2).Should(BeFalse())
-	Expect(delivered3).Should(BeTrue())
-
-	//
-	// The following in the same test as above, but with the values for processing blocks flipped
-	//
-
-	// Cancel the command and stop the relayer
-	relayerCleanup()
-
-	//
-	// Set StartBlockHeight in config
-	//
-	log.Info("Test Setting StartBlockHeight in config")
-
-	// Send three Teleporter messages from subnet A to subnet B
-	log.Info("Sending three Teleporter messages from subnet A to subnet B")
-	_, _, id1 = sendBasicTeleporterMessage(ctx, subnetAInfo, subnetBInfo, fundedKey, fundedAddress)
-	_, _, id2 = sendBasicTeleporterMessage(ctx, subnetAInfo, subnetBInfo, fundedKey, fundedAddress)
-	_, _, id3 = sendBasicTeleporterMessage(ctx, subnetAInfo, subnetBInfo, fundedKey, fundedAddress)
-
-	currHeight, err = subnetAInfo.RPCClient.BlockNumber(ctx)
-	Expect(err).Should(BeNil())
-	log.Info("Current block height", "height", currHeight)
-
-	// Configure the relayer such that it will only process the last of the three messages sent above.
-	// The relayer DB stores the height of the block *before* the first message, so by setting the
-	// StartBlockHeight to the block height of the *third* message, we expect the relayer to skip
-	// the first two messages on startup, but process the third.
-	modifiedRelayerConfig = relayerConfig
-	modifiedRelayerConfig.SourceBlockchains[0].StartBlockHeight = currHeight
-	modifiedRelayerConfig.ProcessHistoricalBlocks = false
-	modifiedRelayerConfig.ProcessMissedBlocks = true
-	relayerConfigPath = writeRelayerConfig(modifiedRelayerConfig)
-
-	log.Info("Starting the relayer")
-	relayerCleanup = testUtils.BuildAndRunRelayerExecutable(ctx, relayerConfigPath)
-	defer relayerCleanup()
-	log.Info("Waiting for a new block confirmation on subnet B")
-	<-newHeadsB
-	delivered1, err = subnetBInfo.TeleporterMessenger.MessageReceived(
-		&bind.CallOpts{}, id1,
-	)
-	Expect(err).Should(BeNil())
-	delivered2, err = subnetBInfo.TeleporterMessenger.MessageReceived(
-		&bind.CallOpts{}, id2,
-	)
-	Expect(err).Should(BeNil())
-	delivered3, err = subnetBInfo.TeleporterMessenger.MessageReceived(
 		&bind.CallOpts{}, id3,
 	)
 	Expect(err).Should(BeNil())

--- a/tests/basic_relay.go
+++ b/tests/basic_relay.go
@@ -164,7 +164,7 @@ func BasicRelay(network interfaces.LocalNetwork) {
 	// the first two messages on startup, but process the third.
 	modifiedRelayerConfig := relayerConfig
 	modifiedRelayerConfig.SourceBlockchains[0].StartBlockHeight = currHeight
-	modifiedRelayerConfig.ProcessMissedBlocks = true
+	modifiedRelayerConfig.ProcessHistoricalBlocks = true
 	relayerConfigPath = writeRelayerConfig(modifiedRelayerConfig)
 
 	log.Info("Starting the relayer")

--- a/tests/basic_relay.go
+++ b/tests/basic_relay.go
@@ -165,6 +165,7 @@ func BasicRelay(network interfaces.LocalNetwork) {
 	modifiedRelayerConfig := relayerConfig
 	modifiedRelayerConfig.SourceBlockchains[0].StartBlockHeight = currHeight
 	modifiedRelayerConfig.ProcessHistoricalBlocks = true
+	modifiedRelayerConfig.ProcessMissedBlocks = false
 	relayerConfigPath = writeRelayerConfig(modifiedRelayerConfig)
 
 	log.Info("Starting the relayer")
@@ -181,6 +182,59 @@ func BasicRelay(network interfaces.LocalNetwork) {
 	)
 	Expect(err).Should(BeNil())
 	delivered3, err := subnetBInfo.TeleporterMessenger.MessageReceived(
+		&bind.CallOpts{}, id3,
+	)
+	Expect(err).Should(BeNil())
+	Expect(delivered1).Should(BeFalse())
+	Expect(delivered2).Should(BeFalse())
+	Expect(delivered3).Should(BeTrue())
+
+	//
+	// The following in the same test as above, but with the values for processing blocks flipped
+	//
+
+	// Cancel the command and stop the relayer
+	relayerCleanup()
+
+	//
+	// Set StartBlockHeight in config
+	//
+	log.Info("Test Setting StartBlockHeight in config")
+
+	// Send three Teleporter messages from subnet A to subnet B
+	log.Info("Sending three Teleporter messages from subnet A to subnet B")
+	_, _, id1 = sendBasicTeleporterMessage(ctx, subnetAInfo, subnetBInfo, fundedKey, fundedAddress)
+	_, _, id2 = sendBasicTeleporterMessage(ctx, subnetAInfo, subnetBInfo, fundedKey, fundedAddress)
+	_, _, id3 = sendBasicTeleporterMessage(ctx, subnetAInfo, subnetBInfo, fundedKey, fundedAddress)
+
+	currHeight, err = subnetAInfo.RPCClient.BlockNumber(ctx)
+	Expect(err).Should(BeNil())
+	log.Info("Current block height", "height", currHeight)
+
+	// Configure the relayer such that it will only process the last of the three messages sent above.
+	// The relayer DB stores the height of the block *before* the first message, so by setting the
+	// StartBlockHeight to the block height of the *third* message, we expect the relayer to skip
+	// the first two messages on startup, but process the third.
+	modifiedRelayerConfig = relayerConfig
+	modifiedRelayerConfig.SourceBlockchains[0].StartBlockHeight = currHeight
+	modifiedRelayerConfig.ProcessHistoricalBlocks = false
+	modifiedRelayerConfig.ProcessMissedBlocks = true
+	relayerConfigPath = writeRelayerConfig(modifiedRelayerConfig)
+
+	log.Info("Starting the relayer")
+	relayerCleanup = testUtils.BuildAndRunRelayerExecutable(ctx, relayerConfigPath)
+	defer relayerCleanup()
+	log.Info("Waiting for a new block confirmation on subnet B")
+	<-newHeadsB
+	delivered1, err = subnetBInfo.TeleporterMessenger.MessageReceived(
+		&bind.CallOpts{}, id1,
+	)
+	Expect(err).Should(BeNil())
+	delivered2, err = subnetBInfo.TeleporterMessenger.MessageReceived(
+		&bind.CallOpts{}, id2,
+	)
+	Expect(err).Should(BeNil())
+	delivered3, err = subnetBInfo.TeleporterMessenger.MessageReceived(
 		&bind.CallOpts{}, id3,
 	)
 	Expect(err).Should(BeNil())

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -139,13 +139,13 @@ func CreateDefaultRelayerConfig(
 	}
 
 	return config.Config{
-		LogLevel:                logging.Info.LowerString(),
-		PChainAPIURL:            subnetsInfo[0].NodeURIs[0],
-		InfoAPIURL:              subnetsInfo[0].NodeURIs[0],
-		StorageLocation:         RelayerStorageLocation(),
-		ProcessMissedBlocks:     false,
-		SourceBlockchains:       sources,
-		DestinationBlockchains:  destinations,
+		LogLevel:               logging.Info.LowerString(),
+		PChainAPIURL:           subnetsInfo[0].NodeURIs[0],
+		InfoAPIURL:             subnetsInfo[0].NodeURIs[0],
+		StorageLocation:        RelayerStorageLocation(),
+		ProcessMissedBlocks:    false,
+		SourceBlockchains:      sources,
+		DestinationBlockchains: destinations,
 	}
 }
 

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -143,7 +143,6 @@ func CreateDefaultRelayerConfig(
 		PChainAPIURL:            subnetsInfo[0].NodeURIs[0],
 		InfoAPIURL:              subnetsInfo[0].NodeURIs[0],
 		StorageLocation:         RelayerStorageLocation(),
-		ProcessHistoricalBlocks: false,
 		ProcessMissedBlocks:     false,
 		SourceBlockchains:       sources,
 		DestinationBlockchains:  destinations,

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -26,10 +26,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var (
-	// Write the test database to /tmp since the data is not needed after the test
-	storageLocation = fmt.Sprintf("%s/.awm-relayer-storage", os.TempDir())
-)
+// Write the test database to /tmp since the data is not needed after the test
+var storageLocation = fmt.Sprintf("%s/.awm-relayer-storage", os.TempDir())
 
 func BuildAndRunRelayerExecutable(ctx context.Context, relayerConfigPath string) context.CancelFunc {
 	// Build the awm-relayer binary
@@ -141,13 +139,14 @@ func CreateDefaultRelayerConfig(
 	}
 
 	return config.Config{
-		LogLevel:               logging.Info.LowerString(),
-		PChainAPIURL:           subnetsInfo[0].NodeURIs[0],
-		InfoAPIURL:             subnetsInfo[0].NodeURIs[0],
-		StorageLocation:        RelayerStorageLocation(),
-		ProcessMissedBlocks:    false,
-		SourceBlockchains:      sources,
-		DestinationBlockchains: destinations,
+		LogLevel:                logging.Info.LowerString(),
+		PChainAPIURL:            subnetsInfo[0].NodeURIs[0],
+		InfoAPIURL:              subnetsInfo[0].NodeURIs[0],
+		StorageLocation:         RelayerStorageLocation(),
+		ProcessHistoricalBlocks: false,
+		ProcessMissedBlocks:     false,
+		SourceBlockchains:       sources,
+		DestinationBlockchains:  destinations,
 	}
 }
 


### PR DESCRIPTION
## Why this should be merged
Previously, we were using `process-missed-blocks` to determine whether to process historical AND missed blocks. This PR splits those out into two different config options.

## How this works
`process-historical-blocks` defaults to `false` will only work if `start-block-height` is set, and will start processing blocks from the greater of `start-block-height` and the last processed block height (if it exists in the db).

`process-missed-blocks` defaults to `true`, and will start processing blocks from the last processed block height (if it exists in the db). If there is no latest block in the db, or `process-missed-blocks` is `false`, we will start processing from the chain head.

## How this was tested

## How is this documented
README