### PR TITLE
Workaround: Ensure all preocompile modules are registered

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,8 +17,13 @@ import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/awm-relayer/utils"
+
 	"github.com/ava-labs/subnet-evm/ethclient"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/warp"
+
+	// Force-load precompiles to trigger registration
+	_ "github.com/ava-labs/subnet-evm/precompile/registry"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/spf13/viper"


### PR DESCRIPTION
## Why this should be merged
Until ```subnet-evm``` fixes this issue in the next release, this workaround will fix https://github.com/ava-labs/awm-relayer/issues/226