### PR TITLE
Support shared DB access

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,12 +230,14 @@ The relayer consists of the following components:
 - At the global level:
   - P2P app network: issues signature `AppRequests`
   - P-Chain client: gets the validators for a Subnet
-  - JSON database: stores latest processed block for each source Subnet
+  - JSON database: stores latest processed block for each Application Relayer
 - Per Source Subnet
   - Subscriber: listens for logs pertaining to cross-chain message transactions
   - Source RPC client: queries for missed blocks on startup
 - Per Destination Subnet
   - Destination RPC client: broadcasts transactions to the destination
+- Application Relayers
+  - Relays messages from a specific source blockchain and source address to a specific destination blockchain and destination address
 
 ### Data Flow
 

--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
-	"github.com/ava-labs/awm-relayer/database"
 	"github.com/ava-labs/awm-relayer/utils"
 
 	"github.com/ava-labs/subnet-evm/ethclient"
@@ -245,14 +244,6 @@ func (c *Config) GetSubnetID(blockchainID ids.ID) ids.ID {
 	return c.blockchainIDToSubnetID[blockchainID]
 }
 
-func (c *Config) GetAllRelayerKeys() []database.RelayerKey {
-	var keys []database.RelayerKey
-	for _, s := range c.SourceBlockchains {
-		keys = append(keys, s.GetRelayerKeys()...)
-	}
-	return keys
-}
-
 func (m *ManualWarpMessage) GetUnsignedMessageBytes() []byte {
 	return m.unsignedMessageBytes
 }
@@ -470,19 +461,6 @@ func (s *SourceBlockchain) GetSubnetID() ids.ID {
 
 func (s *SourceBlockchain) GetBlockchainID() ids.ID {
 	return s.blockchainID
-}
-
-func (s *SourceBlockchain) GetRelayerKeys() []database.RelayerKey {
-	var keys []database.RelayerKey
-	for _, dst := range s.GetSupportedDestinations().List() {
-		keys = append(keys, database.RelayerKey{
-			SourceBlockchainID:      s.GetBlockchainID(),
-			DestinationBlockchainID: dst,
-			OriginSenderAddress:     common.Address{}, // TODO: populate with allowed sender/receiver addresses
-			DestinationAddress:      common.Address{},
-		})
-	}
-	return keys
 }
 
 // Validatees the destination subnet configuration

--- a/config/config.go
+++ b/config/config.go
@@ -95,10 +95,13 @@ type WarpQuorum struct {
 }
 
 type Config struct {
-	LogLevel               string                   `mapstructure:"log-level" json:"log-level"`
-	PChainAPIURL           string                   `mapstructure:"p-chain-api-url" json:"p-chain-api-url"`
-	InfoAPIURL             string                   `mapstructure:"info-api-url" json:"info-api-url"`
-	StorageLocation        string                   `mapstructure:"storage-location" json:"storage-location"`
+	LogLevel        string `mapstructure:"log-level" json:"log-level"`
+	PChainAPIURL    string `mapstructure:"p-chain-api-url" json:"p-chain-api-url"`
+	InfoAPIURL      string `mapstructure:"info-api-url" json:"info-api-url"`
+	StorageLocation string `mapstructure:"storage-location" json:"storage-location"`
+	APIPort         uint64 `mapstructure:"api-port" json:"api-port"`
+	MetricsPort     uint64 `mapstructure:"metrics-port" json:"metrics-port"`
+
 	SourceBlockchains      []*SourceBlockchain      `mapstructure:"source-blockchains" json:"source-blockchains"`
 	DestinationBlockchains []*DestinationBlockchain `mapstructure:"destination-blockchains" json:"destination-blockchains"`
 	ProcessMissedBlocks    bool                     `mapstructure:"process-missed-blocks" json:"process-missed-blocks"`
@@ -112,6 +115,8 @@ func SetDefaultConfigValues(v *viper.Viper) {
 	v.SetDefault(LogLevelKey, logging.Info.String())
 	v.SetDefault(StorageLocationKey, "./.awm-relayer-storage")
 	v.SetDefault(ProcessMissedBlocksKey, true)
+	v.SetDefault(APIPortKey, 8080)
+	v.SetDefault(MetricsPortKey, 9090)
 }
 
 // BuildConfig constructs the relayer config using Viper.
@@ -141,6 +146,8 @@ func BuildConfig(v *viper.Viper) (Config, bool, error) {
 	cfg.InfoAPIURL = v.GetString(InfoAPIURLKey)
 	cfg.StorageLocation = v.GetString(StorageLocationKey)
 	cfg.ProcessMissedBlocks = v.GetBool(ProcessMissedBlocksKey)
+	cfg.APIPort = v.GetUint64(APIPortKey)
+	cfg.MetricsPort = v.GetUint64(MetricsPortKey)
 	if err := v.UnmarshalKey(ManualWarpMessagesKey, &cfg.ManualWarpMessages); err != nil {
 		return Config{}, false, fmt.Errorf("failed to unmarshal manual warp messages: %w", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -99,8 +99,8 @@ type Config struct {
 	PChainAPIURL    string `mapstructure:"p-chain-api-url" json:"p-chain-api-url"`
 	InfoAPIURL      string `mapstructure:"info-api-url" json:"info-api-url"`
 	StorageLocation string `mapstructure:"storage-location" json:"storage-location"`
-	APIPort         uint64 `mapstructure:"api-port" json:"api-port"`
-	MetricsPort     uint64 `mapstructure:"metrics-port" json:"metrics-port"`
+	APIPort         uint16 `mapstructure:"api-port" json:"api-port"`
+	MetricsPort     uint16 `mapstructure:"metrics-port" json:"metrics-port"`
 
 	SourceBlockchains      []*SourceBlockchain      `mapstructure:"source-blockchains" json:"source-blockchains"`
 	DestinationBlockchains []*DestinationBlockchain `mapstructure:"destination-blockchains" json:"destination-blockchains"`
@@ -146,8 +146,8 @@ func BuildConfig(v *viper.Viper) (Config, bool, error) {
 	cfg.InfoAPIURL = v.GetString(InfoAPIURLKey)
 	cfg.StorageLocation = v.GetString(StorageLocationKey)
 	cfg.ProcessMissedBlocks = v.GetBool(ProcessMissedBlocksKey)
-	cfg.APIPort = v.GetUint64(APIPortKey)
-	cfg.MetricsPort = v.GetUint64(MetricsPortKey)
+	cfg.APIPort = v.GetUint16(APIPortKey)
+	cfg.MetricsPort = v.GetUint16(MetricsPortKey)
 	if err := v.UnmarshalKey(ManualWarpMessagesKey, &cfg.ManualWarpMessages); err != nil {
 		return Config{}, false, fmt.Errorf("failed to unmarshal manual warp messages: %w", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/awm-relayer/database"
 	"github.com/ava-labs/awm-relayer/utils"
 
 	"github.com/ava-labs/subnet-evm/ethclient"
@@ -244,25 +245,8 @@ func (c *Config) GetSubnetID(blockchainID ids.ID) ids.ID {
 	return c.blockchainIDToSubnetID[blockchainID]
 }
 
-// TODONOW: Put this somewhere else
-type RelayerKey struct {
-	SourceBlockchainID      ids.ID
-	DestinationBlockchainID ids.ID
-	OriginSenderAddress     common.Address
-	DestinationAddress      common.Address
-}
-
-func (k RelayerKey) CalculateRelayerKey() common.Hash {
-	return utils.CalculateRelayerKey(
-		k.SourceBlockchainID,
-		k.DestinationBlockchainID,
-		k.OriginSenderAddress,
-		k.DestinationAddress,
-	)
-}
-
-func (c *Config) GetAllRelayerKeys() []RelayerKey {
-	var keys []RelayerKey
+func (c *Config) GetAllRelayerKeys() []database.RelayerKey {
+	var keys []database.RelayerKey
 	for _, s := range c.SourceBlockchains {
 		keys = append(keys, s.GetRelayerKeys()...)
 	}
@@ -488,10 +472,10 @@ func (s *SourceBlockchain) GetBlockchainID() ids.ID {
 	return s.blockchainID
 }
 
-func (s *SourceBlockchain) GetRelayerKeys() []RelayerKey {
-	var keys []RelayerKey
+func (s *SourceBlockchain) GetRelayerKeys() []database.RelayerKey {
+	var keys []database.RelayerKey
 	for _, dst := range s.GetSupportedDestinations().List() {
-		keys = append(keys, RelayerKey{
+		keys = append(keys, database.RelayerKey{
 			SourceBlockchainID:      s.GetBlockchainID(),
 			DestinationBlockchainID: dst,
 			OriginSenderAddress:     common.Address{}, // TODO: populate with allowed sender/receiver addresses

--- a/config/keys.go
+++ b/config/keys.go
@@ -9,6 +9,8 @@ const (
 	LogLevelKey               = "log-level"
 	PChainAPIURLKey           = "p-chain-api-url"
 	InfoAPIURLKey             = "info-api-url"
+	APIPortKey                = "api-port"
+	MetricsPortKey            = "metrics-port"
 	SourceBlockchainsKey      = "source-blockchains"
 	DestinationBlockchainsKey = "destination-blockchains"
 	AccountPrivateKeyKey      = "account-private-key"

--- a/database/database.go
+++ b/database/database.go
@@ -6,6 +6,8 @@
 package database
 
 import (
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/awm-relayer/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 )
@@ -24,4 +26,20 @@ var (
 type RelayerDatabase interface {
 	Get(relayerKey common.Hash, key []byte) ([]byte, error)
 	Put(relayerKey common.Hash, key []byte, value []byte) error
+}
+
+type RelayerKey struct {
+	SourceBlockchainID      ids.ID
+	DestinationBlockchainID ids.ID
+	OriginSenderAddress     common.Address
+	DestinationAddress      common.Address
+}
+
+func (k RelayerKey) CalculateRelayerKey() common.Hash {
+	return utils.CalculateRelayerKey(
+		k.SourceBlockchainID,
+		k.DestinationBlockchainID,
+		k.OriginSenderAddress,
+		k.DestinationAddress,
+	)
 }

--- a/database/database.go
+++ b/database/database.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/awm-relayer/config"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/pkg/errors"
@@ -63,4 +64,24 @@ func CalculateRelayerKey(
 			"-",
 		)),
 	)
+}
+
+func GetConfigRelayerKeys(cfg *config.Config) []RelayerKey {
+	var keys []RelayerKey
+	for _, s := range cfg.SourceBlockchains {
+		keys = append(keys, GetSourceConfigRelayerKeys(s)...)
+	}
+	return keys
+}
+func GetSourceConfigRelayerKeys(cfg *config.SourceBlockchain) []RelayerKey {
+	var keys []RelayerKey
+	for _, dst := range cfg.GetSupportedDestinations().List() {
+		keys = append(keys, RelayerKey{
+			SourceBlockchainID:      cfg.GetBlockchainID(),
+			DestinationBlockchainID: dst,
+			OriginSenderAddress:     common.Address{}, // TODO: populate with allowed sender/receiver addresses
+			DestinationAddress:      common.Address{},
+		})
+	}
+	return keys
 }

--- a/database/database.go
+++ b/database/database.go
@@ -20,15 +20,20 @@ const (
 )
 
 var (
-	ErrKeyNotFound              = errors.New("key not found")
-	ErrChainNotFound            = errors.New("no database for chain")
+	ErrDataKeyNotFound          = errors.New("data key not found")
+	ErrRelayerKeyNotFound       = errors.New("no database for relayer key")
 	ErrDatabaseMisconfiguration = errors.New("database misconfiguration")
 )
 
 // RelayerDatabase is a key-value store for relayer state, with each blockchainID maintaining its own state
 type RelayerDatabase interface {
-	Get(relayerKey common.Hash, key []byte) ([]byte, error)
-	Put(relayerKey common.Hash, key []byte, value []byte) error
+	Get(relayerKey common.Hash, dataKey []byte) ([]byte, error)
+	Put(relayerKey common.Hash, dataKey []byte, value []byte) error
+}
+
+// Returns true if an error returned by a RelayerDatabase indicates the requested key was not found
+func IsKeyNotFoundError(err error) bool {
+	return errors.Is(err, ErrRelayerKeyNotFound) || errors.Is(err, ErrDataKeyNotFound)
 }
 
 // RelayerKey is a unique identifier for an application relayer

--- a/database/database.go
+++ b/database/database.go
@@ -31,6 +31,7 @@ type RelayerDatabase interface {
 	Put(relayerKey common.Hash, key []byte, value []byte) error
 }
 
+// RelayerKey is a unique identifier for an application relayer
 type RelayerKey struct {
 	SourceBlockchainID      ids.ID
 	DestinationBlockchainID ids.ID
@@ -38,6 +39,7 @@ type RelayerKey struct {
 	DestinationAddress      common.Address
 }
 
+// CalculateRelayerKey calculates the unique identifier for an application relayer
 func (k RelayerKey) CalculateRelayerKey() common.Hash {
 	return CalculateRelayerKey(
 		k.SourceBlockchainID,
@@ -47,6 +49,7 @@ func (k RelayerKey) CalculateRelayerKey() common.Hash {
 	)
 }
 
+// Standalone utility to calculate a relayer key
 func CalculateRelayerKey(
 	sourceBlockchainID ids.ID,
 	destinationBlockchainID ids.ID,
@@ -66,6 +69,7 @@ func CalculateRelayerKey(
 	)
 }
 
+// Get all of the possible relayer keys for a given configuration
 func GetConfigRelayerKeys(cfg *config.Config) []RelayerKey {
 	var keys []RelayerKey
 	for _, s := range cfg.SourceBlockchains {
@@ -73,6 +77,8 @@ func GetConfigRelayerKeys(cfg *config.Config) []RelayerKey {
 	}
 	return keys
 }
+
+// Calculate all of the possible relayer keys for a given source blockchain
 func GetSourceConfigRelayerKeys(cfg *config.SourceBlockchain) []RelayerKey {
 	var keys []RelayerKey
 	for _, dst := range cfg.GetSupportedDestinations().List() {

--- a/database/database.go
+++ b/database/database.go
@@ -15,20 +15,30 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	LatestProcessedBlockKey = "latestProcessedBlock"
-)
-
 var (
 	ErrDataKeyNotFound          = errors.New("data key not found")
 	ErrRelayerKeyNotFound       = errors.New("no database for relayer key")
 	ErrDatabaseMisconfiguration = errors.New("database misconfiguration")
 )
 
+const (
+	LatestProcessedBlockKey DataKey = iota
+)
+
+type DataKey int
+
+func (k DataKey) String() string {
+	switch k {
+	case LatestProcessedBlockKey:
+		return "latestProcessedBlock"
+	}
+	return "unknown"
+}
+
 // RelayerDatabase is a key-value store for relayer state, with each relayerKey maintaining its own state
 type RelayerDatabase interface {
-	Get(relayerKey common.Hash, dataKey []byte) ([]byte, error)
-	Put(relayerKey common.Hash, dataKey []byte, value []byte) error
+	Get(relayerKey common.Hash, dataKey DataKey) ([]byte, error)
+	Put(relayerKey common.Hash, dataKey DataKey, value []byte) error
 }
 
 // Returns true if an error returned by a RelayerDatabase indicates the requested key was not found

--- a/database/database.go
+++ b/database/database.go
@@ -6,9 +6,11 @@
 package database
 
 import (
+	"strings"
+
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/awm-relayer/utils"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/pkg/errors"
 )
 
@@ -36,10 +38,29 @@ type RelayerKey struct {
 }
 
 func (k RelayerKey) CalculateRelayerKey() common.Hash {
-	return utils.CalculateRelayerKey(
+	return CalculateRelayerKey(
 		k.SourceBlockchainID,
 		k.DestinationBlockchainID,
 		k.OriginSenderAddress,
 		k.DestinationAddress,
+	)
+}
+
+func CalculateRelayerKey(
+	sourceBlockchainID ids.ID,
+	destinationBlockchainID ids.ID,
+	originSenderAddress common.Address,
+	desinationAddress common.Address,
+) common.Hash {
+	return crypto.Keccak256Hash(
+		[]byte(strings.Join(
+			[]string{
+				sourceBlockchainID.String(),
+				destinationBlockchainID.String(),
+				originSenderAddress.String(),
+				desinationAddress.String(),
+			},
+			"-",
+		)),
 	)
 }

--- a/database/database.go
+++ b/database/database.go
@@ -78,17 +78,17 @@ func CalculateRelayerKey(
 func GetConfigRelayerKeys(cfg *config.Config) []RelayerKey {
 	var keys []RelayerKey
 	for _, s := range cfg.SourceBlockchains {
-		keys = append(keys, GetSourceConfigRelayerKeys(s)...)
+		keys = append(keys, GetSourceBlockchainRelayerKeys(s)...)
 	}
 	return keys
 }
 
 // Calculate all of the possible relayer keys for a given source blockchain
-func GetSourceConfigRelayerKeys(cfg *config.SourceBlockchain) []RelayerKey {
+func GetSourceBlockchainRelayerKeys(sourceBlockchain *config.SourceBlockchain) []RelayerKey {
 	var keys []RelayerKey
-	for _, dst := range cfg.GetSupportedDestinations().List() {
+	for _, dst := range sourceBlockchain.GetSupportedDestinations().List() {
 		keys = append(keys, RelayerKey{
-			SourceBlockchainID:      cfg.GetBlockchainID(),
+			SourceBlockchainID:      sourceBlockchain.GetBlockchainID(),
 			DestinationBlockchainID: dst,
 			OriginSenderAddress:     common.Address{}, // TODO: populate with allowed sender/receiver addresses
 			DestinationAddress:      common.Address{},

--- a/database/database.go
+++ b/database/database.go
@@ -6,7 +6,7 @@
 package database
 
 import (
-	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 )
 
@@ -22,6 +22,6 @@ var (
 
 // RelayerDatabase is a key-value store for relayer state, with each blockchainID maintaining its own state
 type RelayerDatabase interface {
-	Get(blockchainID ids.ID, key []byte) ([]byte, error)
-	Put(blockchainID ids.ID, key []byte, value []byte) error
+	Get(relayerKey common.Hash, key []byte) ([]byte, error)
+	Put(relayerKey common.Hash, key []byte, value []byte) error
 }

--- a/database/database.go
+++ b/database/database.go
@@ -25,7 +25,7 @@ var (
 	ErrDatabaseMisconfiguration = errors.New("database misconfiguration")
 )
 
-// RelayerDatabase is a key-value store for relayer state, with each blockchainID maintaining its own state
+// RelayerDatabase is a key-value store for relayer state, with each relayerKey maintaining its own state
 type RelayerDatabase interface {
 	Get(relayerKey common.Hash, dataKey []byte) ([]byte, error)
 	Put(relayerKey common.Hash, dataKey []byte, value []byte) error

--- a/database/database.go
+++ b/database/database.go
@@ -42,16 +42,20 @@ type RelayerKey struct {
 	DestinationBlockchainID ids.ID
 	OriginSenderAddress     common.Address
 	DestinationAddress      common.Address
+	key                     common.Hash
 }
 
-// CalculateRelayerKey calculates the unique identifier for an application relayer
-func (k RelayerKey) CalculateRelayerKey() common.Hash {
-	return CalculateRelayerKey(
-		k.SourceBlockchainID,
-		k.DestinationBlockchainID,
-		k.OriginSenderAddress,
-		k.DestinationAddress,
-	)
+// GetKey returns the unique identifier for an application relayer
+func (k *RelayerKey) GetKey() common.Hash {
+	if k.key == (common.Hash{}) {
+		k.key = CalculateRelayerKey(
+			k.SourceBlockchainID,
+			k.DestinationBlockchainID,
+			k.OriginSenderAddress,
+			k.DestinationAddress,
+		)
+	}
+	return k.key
 }
 
 // Standalone utility to calculate a relayer key

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -17,12 +17,12 @@ func TestIsKeyNotFoundError(t *testing.T) {
 	}{
 		{
 			name:     "key not found error",
-			err:      ErrDataKeyNotFound,
+			err:      ErrKeyNotFound,
 			expected: true,
 		},
 		{
 			name:     "relayer key not found error",
-			err:      ErrRelayerKeyNotFound,
+			err:      ErrRelayerIDNotFound,
 			expected: true,
 		},
 		{
@@ -37,7 +37,7 @@ func TestIsKeyNotFoundError(t *testing.T) {
 	}
 }
 
-func TestCalculateRelayerKey(t *testing.T) {
+func TestCalculateRelayerID(t *testing.T) {
 	id1, _ := ids.FromString("S4mMqUXe7vHsGiRAma6bv3CKnyaLssyAxmQ2KvFpX1KEvfFCD")
 	id2, _ := ids.FromString("2TGBXcnwx5PqiXWiqxAKUaNSqDguXNh1mxnp82jui68hxJSZAx")
 	zeroAddress := common.HexToAddress("0x0000000000000000000000000000000000000000")
@@ -83,7 +83,7 @@ func TestCalculateRelayerKey(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		result := CalculateRelayerKey(
+		result := CalculateRelayerID(
 			testCase.sourceBlockchainID,
 			testCase.destinationBlockchainID,
 			testCase.originSenderAddress,

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -1,0 +1,94 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsKeyNotFoundError(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "key not found error",
+			err:      ErrDataKeyNotFound,
+			expected: true,
+		},
+		{
+			name:     "relayer key not found error",
+			err:      ErrRelayerKeyNotFound,
+			expected: true,
+		},
+		{
+			name:     "unknown error",
+			err:      errors.New("unknown error"),
+			expected: false,
+		},
+	}
+	for _, testCase := range testCases {
+		result := IsKeyNotFoundError(testCase.err)
+		require.Equal(t, testCase.expected, result, testCase.name)
+	}
+}
+
+func TestCalculateRelayerKey(t *testing.T) {
+	id1, _ := ids.FromString("S4mMqUXe7vHsGiRAma6bv3CKnyaLssyAxmQ2KvFpX1KEvfFCD")
+	id2, _ := ids.FromString("2TGBXcnwx5PqiXWiqxAKUaNSqDguXNh1mxnp82jui68hxJSZAx")
+	zeroAddress := common.HexToAddress("0x0000000000000000000000000000000000000000")
+	testCases := []struct {
+		name                    string
+		sourceBlockchainID      ids.ID
+		destinationBlockchainID ids.ID
+		originSenderAddress     common.Address
+		destinationAddress      common.Address
+		expected                common.Hash
+	}{
+		{
+			name:                    "all zero",
+			sourceBlockchainID:      id1,
+			destinationBlockchainID: id2,
+			originSenderAddress:     zeroAddress,
+			destinationAddress:      zeroAddress,
+			expected:                common.HexToHash("0xf8a8467088fd6f8ad4577408ddda1607e2702ca9827d7fd556c46adae624b7a2"),
+		},
+		{
+			name:                    "zero source address",
+			sourceBlockchainID:      id1,
+			destinationBlockchainID: id2,
+			originSenderAddress:     zeroAddress,
+			destinationAddress:      common.HexToAddress("0x0123456789abcdef0123456789abcdef01234567"),
+			expected:                common.HexToHash("0xa20ede2231d43d072800ad436a4ca8844f9ddd9cb4174f4cc3046e0958e48320"),
+		},
+		{
+			name:                    "zero destination address",
+			sourceBlockchainID:      id1,
+			destinationBlockchainID: id2,
+			originSenderAddress:     common.HexToAddress("0x0123456789abcdef0123456789abcdef01234567"),
+			destinationAddress:      zeroAddress,
+			expected:                common.HexToHash("0xb205a049831478f55b768a4c875b2085339b6053831ecde8a3d406f9d13454a5"),
+		},
+		{
+			name:                    "all non-zero",
+			sourceBlockchainID:      id1,
+			destinationBlockchainID: id2,
+			originSenderAddress:     common.HexToAddress("0x0123456789abcdef0123456789abcdef01234567"),
+			destinationAddress:      common.HexToAddress("0x0123456789abcdef0123456789abcdef01234567"),
+			expected:                common.HexToHash("0x6661512bc3b5689b28a4c2519425f725b5681b90fea937433103c846f742f918"),
+		},
+	}
+	for _, testCase := range testCases {
+		result := CalculateRelayerKey(
+			testCase.sourceBlockchainID,
+			testCase.destinationBlockchainID,
+			testCase.originSenderAddress,
+			testCase.destinationAddress,
+		)
+		require.Equal(t, testCase.expected, result, testCase.name)
+	}
+}

--- a/database/json_file_storage.go
+++ b/database/json_file_storage.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/awm-relayer/config"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -35,8 +34,7 @@ type JSONFileStorage struct {
 }
 
 // NewJSONFileStorage creates a new JSONFileStorage instance
-func NewJSONFileStorage(logger logging.Logger, cfg config.Config) (*JSONFileStorage, error) {
-	dir := cfg.StorageLocation
+func NewJSONFileStorage(logger logging.Logger, dir string, relayerKeys []RelayerKey) (*JSONFileStorage, error) {
 	storage := &JSONFileStorage{
 		dir:          filepath.Clean(dir),
 		mutexes:      make(map[common.Hash]*sync.RWMutex),
@@ -44,7 +42,7 @@ func NewJSONFileStorage(logger logging.Logger, cfg config.Config) (*JSONFileStor
 		currentState: make(map[common.Hash]chainState),
 	}
 
-	for _, relayerKey := range cfg.GetAllRelayerKeys() {
+	for _, relayerKey := range relayerKeys {
 		key := relayerKey.CalculateRelayerKey()
 		storage.currentState[key] = make(chainState)
 		storage.mutexes[key] = &sync.RWMutex{}
@@ -54,7 +52,7 @@ func NewJSONFileStorage(logger logging.Logger, cfg config.Config) (*JSONFileStor
 	if err == nil {
 		// Directory already exists.
 		// Read the existing storage.
-		for _, relayerKey := range cfg.GetAllRelayerKeys() {
+		for _, relayerKey := range relayerKeys {
 			key := relayerKey.CalculateRelayerKey()
 			currentState, fileExists, err := storage.getCurrentState(key)
 			if err != nil {

--- a/database/json_file_storage.go
+++ b/database/json_file_storage.go
@@ -26,7 +26,7 @@ type JSONFileStorage struct {
 	dir string
 
 	// Each network has its own mutex
-	// The blockchainIDs used to index the JSONFileStorage are created at initialization
+	// The RelayerKeys used to index the JSONFileStorage are created at initialization
 	// and are not modified afterwards, so we don't need to lock the map itself.
 	mutexes      map[common.Hash]*sync.RWMutex
 	logger       logging.Logger
@@ -107,14 +107,14 @@ func (s *JSONFileStorage) Get(relayerKey common.Hash, dataKey []byte) ([]byte, e
 	return []byte(val), nil
 }
 
-// Helper to get the current state of a blockchainID. Not thread-safe.
+// Helper to get the current state of a relayerKey. Not thread-safe.
 func (s *JSONFileStorage) getCurrentState(relayerKey common.Hash) (chainState, bool, error) {
 	currentState := make(chainState)
 	fileExists, err := s.read(relayerKey, &currentState)
 	if err != nil {
 		s.logger.Error(
 			"failed to read file",
-			zap.String("blockchainID", relayerKey.String()),
+			zap.String("relayerKey", relayerKey.String()),
 			zap.Error(err),
 		)
 		return nil, false, err
@@ -123,7 +123,7 @@ func (s *JSONFileStorage) getCurrentState(relayerKey common.Hash) (chainState, b
 }
 
 // Put the value into the JSON database. Read the current chain state and overwrite the key, if it exists
-// If the file corresponding to {blockchainID} does not exist, then it will be created
+// If the file corresponding to {relayerKey} does not exist, then it will be created
 func (s *JSONFileStorage) Put(relayerKey common.Hash, dataKey []byte, value []byte) error {
 	mutex, ok := s.mutexes[relayerKey]
 	if !ok {

--- a/database/json_file_storage.go
+++ b/database/json_file_storage.go
@@ -141,9 +141,13 @@ func (s *JSONFileStorage) Put(relayerID common.Hash, dataKey DataKey, value []by
 	return s.write(relayerID, s.currentState[relayerID])
 }
 
+func (s *JSONFileStorage) getFileName(relayerID common.Hash) string {
+	return filepath.Join(s.dir, relayerID.String()+".json")
+}
+
 // Write the value to the file. The caller is responsible for ensuring proper synchronization
 func (s *JSONFileStorage) write(relayerID common.Hash, v interface{}) error {
-	fnlPath := filepath.Join(s.dir, relayerID.String()+".json")
+	fnlPath := s.getFileName(relayerID)
 	tmpPath := fnlPath + ".tmp"
 
 	b, err := json.MarshalIndent(v, "", "\t")
@@ -172,7 +176,7 @@ func (s *JSONFileStorage) write(relayerID common.Hash, v interface{}) error {
 // If an error is returned, the bool should be ignored.
 // The caller is responsible for ensuring proper synchronization
 func (s *JSONFileStorage) read(relayerID common.Hash, v interface{}) (bool, error) {
-	path := filepath.Join(s.dir, relayerID.String()+".json")
+	path := s.getFileName(relayerID)
 
 	// If the file does not exist, return false, but do not return an error as this
 	// is an expected case

--- a/database/json_file_storage.go
+++ b/database/json_file_storage.go
@@ -10,9 +10,9 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/awm-relayer/config"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -29,40 +29,42 @@ type JSONFileStorage struct {
 	// Each network has its own mutex
 	// The blockchainIDs used to index the JSONFileStorage are created at initialization
 	// and are not modified afterwards, so we don't need to lock the map itself.
-	mutexes      map[ids.ID]*sync.RWMutex
+	mutexes      map[common.Hash]*sync.RWMutex
 	logger       logging.Logger
-	currentState map[ids.ID]chainState
+	currentState map[common.Hash]chainState
 }
 
 // NewJSONFileStorage creates a new JSONFileStorage instance
-func NewJSONFileStorage(logger logging.Logger, dir string, sourceBlockchains []*config.SourceBlockchain) (*JSONFileStorage, error) {
+func NewJSONFileStorage(logger logging.Logger, cfg config.Config) (*JSONFileStorage, error) {
+	dir := cfg.StorageLocation
 	storage := &JSONFileStorage{
 		dir:          filepath.Clean(dir),
-		mutexes:      make(map[ids.ID]*sync.RWMutex),
+		mutexes:      make(map[common.Hash]*sync.RWMutex),
 		logger:       logger,
-		currentState: make(map[ids.ID]chainState),
+		currentState: make(map[common.Hash]chainState),
 	}
 
-	for _, sourceBlockchain := range sourceBlockchains {
-		sourceBlockchainID := sourceBlockchain.GetBlockchainID()
-		storage.currentState[sourceBlockchainID] = make(chainState)
-		storage.mutexes[sourceBlockchainID] = &sync.RWMutex{}
+	for _, relayerKey := range cfg.GetAllRelayerKeys() {
+		key := relayerKey.CalculateRelayerKey()
+		storage.currentState[key] = make(chainState)
+		storage.mutexes[key] = &sync.RWMutex{}
 	}
 
 	_, err := os.Stat(dir)
 	if err == nil {
 		// Directory already exists.
 		// Read the existing storage.
-		for _, sourceBlockchain := range sourceBlockchains {
-			sourceBlockchainID := sourceBlockchain.GetBlockchainID()
-			currentState, fileExists, err := storage.getCurrentState(sourceBlockchainID)
+		for _, relayerKey := range cfg.GetAllRelayerKeys() {
+			key := relayerKey.CalculateRelayerKey()
+			currentState, fileExists, err := storage.getCurrentState(key)
 			if err != nil {
 				return nil, err
 			}
 			if fileExists {
-				storage.currentState[sourceBlockchainID] = currentState
+				storage.currentState[key] = currentState
 			}
 		}
+
 		return storage, nil
 	}
 
@@ -80,18 +82,18 @@ func NewJSONFileStorage(logger logging.Logger, dir string, sourceBlockchains []*
 }
 
 // Get the latest chain state from the JSON database, and retrieve the value from the key
-func (s *JSONFileStorage) Get(blockchainID ids.ID, key []byte) ([]byte, error) {
-	mutex, ok := s.mutexes[blockchainID]
+func (s *JSONFileStorage) Get(relayerKey common.Hash, key []byte) ([]byte, error) {
+	mutex, ok := s.mutexes[relayerKey]
 	if !ok {
 		return nil, errors.Wrap(
 			ErrDatabaseMisconfiguration,
-			fmt.Sprintf("database not configured for chain %s", blockchainID.String()),
+			fmt.Sprintf("database not configured for key %s", relayerKey.String()),
 		)
 	}
 
 	mutex.RLock()
 	defer mutex.RUnlock()
-	currentState, fileExists, err := s.getCurrentState(blockchainID)
+	currentState, fileExists, err := s.getCurrentState(relayerKey)
 	if err != nil {
 		return nil, err
 	}
@@ -108,13 +110,13 @@ func (s *JSONFileStorage) Get(blockchainID ids.ID, key []byte) ([]byte, error) {
 }
 
 // Helper to get the current state of a blockchainID. Not thread-safe.
-func (s *JSONFileStorage) getCurrentState(blockchainID ids.ID) (chainState, bool, error) {
+func (s *JSONFileStorage) getCurrentState(relayerKey common.Hash) (chainState, bool, error) {
 	currentState := make(chainState)
-	fileExists, err := s.read(blockchainID, &currentState)
+	fileExists, err := s.read(relayerKey, &currentState)
 	if err != nil {
 		s.logger.Error(
 			"failed to read file",
-			zap.String("blockchainID", blockchainID.String()),
+			zap.String("blockchainID", relayerKey.String()),
 			zap.Error(err),
 		)
 		return nil, false, err
@@ -124,12 +126,12 @@ func (s *JSONFileStorage) getCurrentState(blockchainID ids.ID) (chainState, bool
 
 // Put the value into the JSON database. Read the current chain state and overwrite the key, if it exists
 // If the file corresponding to {blockchainID} does not exist, then it will be created
-func (s *JSONFileStorage) Put(blockchainID ids.ID, key []byte, value []byte) error {
-	mutex, ok := s.mutexes[blockchainID]
+func (s *JSONFileStorage) Put(relayerKey common.Hash, key []byte, value []byte) error {
+	mutex, ok := s.mutexes[relayerKey]
 	if !ok {
 		return errors.Wrap(
 			ErrDatabaseMisconfiguration,
-			fmt.Sprintf("database not configured for chain %s", blockchainID.String()),
+			fmt.Sprintf("database not configured for key %s", relayerKey.String()),
 		)
 	}
 
@@ -137,13 +139,13 @@ func (s *JSONFileStorage) Put(blockchainID ids.ID, key []byte, value []byte) err
 	defer mutex.Unlock()
 
 	// Update the in-memory state and write to disk
-	s.currentState[blockchainID][string(key)] = string(value)
-	return s.write(blockchainID, s.currentState[blockchainID])
+	s.currentState[relayerKey][string(key)] = string(value)
+	return s.write(relayerKey, s.currentState[relayerKey])
 }
 
 // Write the value to the file. The caller is responsible for ensuring proper synchronization
-func (s *JSONFileStorage) write(blockchainID ids.ID, v interface{}) error {
-	fnlPath := filepath.Join(s.dir, blockchainID.String()+".json")
+func (s *JSONFileStorage) write(relayerKey common.Hash, v interface{}) error {
+	fnlPath := filepath.Join(s.dir, relayerKey.String()+".json")
 	tmpPath := fnlPath + ".tmp"
 
 	b, err := json.MarshalIndent(v, "", "\t")
@@ -171,8 +173,8 @@ func (s *JSONFileStorage) write(blockchainID ids.ID, v interface{}) error {
 // Returns a bool indicating whether the file exists, and an error.
 // If an error is returned, the bool should be ignored.
 // The caller is responsible for ensuring proper synchronization
-func (s *JSONFileStorage) read(blockchainID ids.ID, v interface{}) (bool, error) {
-	path := filepath.Join(s.dir, blockchainID.String()+".json")
+func (s *JSONFileStorage) read(relayerKey common.Hash, v interface{}) (bool, error) {
+	path := filepath.Join(s.dir, relayerKey.String()+".json")
 
 	// If the file does not exist, return false, but do not return an error as this
 	// is an expected case

--- a/database/json_file_storage.go
+++ b/database/json_file_storage.go
@@ -43,7 +43,7 @@ func NewJSONFileStorage(logger logging.Logger, dir string, relayerKeys []Relayer
 	}
 
 	for _, relayerKey := range relayerKeys {
-		key := relayerKey.CalculateRelayerKey()
+		key := relayerKey.GetKey()
 		storage.currentState[key] = make(chainState)
 		storage.mutexes[key] = &sync.RWMutex{}
 	}
@@ -53,7 +53,7 @@ func NewJSONFileStorage(logger logging.Logger, dir string, relayerKeys []Relayer
 		// Directory already exists.
 		// Read the existing storage.
 		for _, relayerKey := range relayerKeys {
-			key := relayerKey.CalculateRelayerKey()
+			key := relayerKey.GetKey()
 			currentState, fileExists, err := storage.getCurrentState(key)
 			if err != nil {
 				return nil, err

--- a/database/json_file_storage.go
+++ b/database/json_file_storage.go
@@ -80,7 +80,7 @@ func NewJSONFileStorage(logger logging.Logger, dir string, relayerKeys []Relayer
 }
 
 // Get the latest chain state from the JSON database, and retrieve the value from the key
-func (s *JSONFileStorage) Get(relayerKey common.Hash, key []byte) ([]byte, error) {
+func (s *JSONFileStorage) Get(relayerKey common.Hash, dataKey []byte) ([]byte, error) {
 	mutex, ok := s.mutexes[relayerKey]
 	if !ok {
 		return nil, errors.Wrap(
@@ -96,12 +96,12 @@ func (s *JSONFileStorage) Get(relayerKey common.Hash, key []byte) ([]byte, error
 		return nil, err
 	}
 	if !fileExists {
-		return nil, ErrChainNotFound
+		return nil, ErrRelayerKeyNotFound
 	}
 
 	var val string
-	if val, ok = currentState[string(key)]; !ok {
-		return nil, ErrKeyNotFound
+	if val, ok = currentState[string(dataKey)]; !ok {
+		return nil, ErrDataKeyNotFound
 	}
 
 	return []byte(val), nil
@@ -124,7 +124,7 @@ func (s *JSONFileStorage) getCurrentState(relayerKey common.Hash) (chainState, b
 
 // Put the value into the JSON database. Read the current chain state and overwrite the key, if it exists
 // If the file corresponding to {blockchainID} does not exist, then it will be created
-func (s *JSONFileStorage) Put(relayerKey common.Hash, key []byte, value []byte) error {
+func (s *JSONFileStorage) Put(relayerKey common.Hash, dataKey []byte, value []byte) error {
 	mutex, ok := s.mutexes[relayerKey]
 	if !ok {
 		return errors.Wrap(
@@ -137,7 +137,7 @@ func (s *JSONFileStorage) Put(relayerKey common.Hash, key []byte, value []byte) 
 	defer mutex.Unlock()
 
 	// Update the in-memory state and write to disk
-	s.currentState[relayerKey][string(key)] = string(value)
+	s.currentState[relayerKey][string(dataKey)] = string(value)
 	return s.write(relayerKey, s.currentState[relayerKey])
 }
 

--- a/database/json_file_storage.go
+++ b/database/json_file_storage.go
@@ -80,7 +80,7 @@ func NewJSONFileStorage(logger logging.Logger, dir string, relayerKeys []Relayer
 }
 
 // Get the latest chain state from the JSON database, and retrieve the value from the key
-func (s *JSONFileStorage) Get(relayerKey common.Hash, dataKey []byte) ([]byte, error) {
+func (s *JSONFileStorage) Get(relayerKey common.Hash, dataKey DataKey) ([]byte, error) {
 	mutex, ok := s.mutexes[relayerKey]
 	if !ok {
 		return nil, errors.Wrap(
@@ -100,7 +100,7 @@ func (s *JSONFileStorage) Get(relayerKey common.Hash, dataKey []byte) ([]byte, e
 	}
 
 	var val string
-	if val, ok = currentState[string(dataKey)]; !ok {
+	if val, ok = currentState[dataKey.String()]; !ok {
 		return nil, ErrDataKeyNotFound
 	}
 
@@ -124,7 +124,7 @@ func (s *JSONFileStorage) getCurrentState(relayerKey common.Hash) (chainState, b
 
 // Put the value into the JSON database. Read the current chain state and overwrite the key, if it exists
 // If the file corresponding to {relayerKey} does not exist, then it will be created
-func (s *JSONFileStorage) Put(relayerKey common.Hash, dataKey []byte, value []byte) error {
+func (s *JSONFileStorage) Put(relayerKey common.Hash, dataKey DataKey, value []byte) error {
 	mutex, ok := s.mutexes[relayerKey]
 	if !ok {
 		return errors.Wrap(
@@ -137,7 +137,7 @@ func (s *JSONFileStorage) Put(relayerKey common.Hash, dataKey []byte, value []by
 	defer mutex.Unlock()
 
 	// Update the in-memory state and write to disk
-	s.currentState[relayerKey][string(dataKey)] = string(value)
+	s.currentState[relayerKey][dataKey.String()] = string(value)
 	return s.write(relayerKey, s.currentState[relayerKey])
 }
 

--- a/database/json_file_storage_test.go
+++ b/database/json_file_storage_test.go
@@ -3,36 +3,30 @@
 
 package database
 
-import (
-	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/utils/set"
-	"github.com/ava-labs/awm-relayer/config"
-)
+// var validSourceBlockchainConfig = &config.SourceBlockchain{
+// 	RPCEndpoint:  "http://test.avax.network/ext/bc/C/rpc",
+// 	WSEndpoint:   "ws://test.avax.network/ext/bc/C/ws",
+// 	BlockchainID: "S4mMqUXe7vHsGiRAma6bv3CKnyaLssyAxmQ2KvFpX1KEvfFCD",
+// 	SubnetID:     "2TGBXcnwx5PqiXWiqxAKUaNSqDguXNh1mxnp82jui68hxJSZAx",
+// 	VM:           "evm",
+// 	MessageContracts: map[string]config.MessageProtocolConfig{
+// 		"0xd81545385803bCD83bd59f58Ba2d2c0562387F83": {
+// 			MessageFormat: config.TELEPORTER.String(),
+// 		},
+// 	},
+// }
 
-var validSourceBlockchainConfig = &config.SourceBlockchain{
-	RPCEndpoint:  "http://test.avax.network/ext/bc/C/rpc",
-	WSEndpoint:   "ws://test.avax.network/ext/bc/C/ws",
-	BlockchainID: "S4mMqUXe7vHsGiRAma6bv3CKnyaLssyAxmQ2KvFpX1KEvfFCD",
-	SubnetID:     "2TGBXcnwx5PqiXWiqxAKUaNSqDguXNh1mxnp82jui68hxJSZAx",
-	VM:           "evm",
-	MessageContracts: map[string]config.MessageProtocolConfig{
-		"0xd81545385803bCD83bd59f58Ba2d2c0562387F83": {
-			MessageFormat: config.TELEPORTER.String(),
-		},
-	},
-}
-
-func populateSourceConfig(blockchainIDs []ids.ID) []*config.SourceBlockchain {
-	sourceBlockchains := make([]*config.SourceBlockchain, len(blockchainIDs))
-	for i, id := range blockchainIDs {
-		sourceBlockchains[i] = validSourceBlockchainConfig
-		sourceBlockchains[i].BlockchainID = id.String()
-	}
-	destinationsBlockchainIDs := set.NewSet[string](1) // just needs to be non-nil
-	destinationsBlockchainIDs.Add(ids.GenerateTestID().String())
-	sourceBlockchains[0].Validate(&destinationsBlockchainIDs)
-	return sourceBlockchains
-}
+// func populateSourceConfig(blockchainIDs []ids.ID) []*config.SourceBlockchain {
+// 	sourceBlockchains := make([]*config.SourceBlockchain, len(blockchainIDs))
+// 	for i, id := range blockchainIDs {
+// 		sourceBlockchains[i] = validSourceBlockchainConfig
+// 		sourceBlockchains[i].BlockchainID = id.String()
+// 	}
+// 	destinationsBlockchainIDs := set.NewSet[string](1) // just needs to be non-nil
+// 	destinationsBlockchainIDs.Add(ids.GenerateTestID().String())
+// 	sourceBlockchains[0].Validate(&destinationsBlockchainIDs)
+// 	return sourceBlockchains
+// }
 
 // Test that the JSON database can write and read to a single chain concurrently.
 // func TestConcurrentWriteReadSingleChain(t *testing.T) {

--- a/database/json_file_storage_test.go
+++ b/database/json_file_storage_test.go
@@ -14,22 +14,8 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
-	"github.com/ava-labs/awm-relayer/config"
 	"github.com/stretchr/testify/assert"
 )
-
-var validSourceBlockchainConfig = &config.SourceBlockchain{
-	RPCEndpoint:  "http://test.avax.network/ext/bc/C/rpc",
-	WSEndpoint:   "ws://test.avax.network/ext/bc/C/ws",
-	BlockchainID: "S4mMqUXe7vHsGiRAma6bv3CKnyaLssyAxmQ2KvFpX1KEvfFCD",
-	SubnetID:     "2TGBXcnwx5PqiXWiqxAKUaNSqDguXNh1mxnp82jui68hxJSZAx",
-	VM:           "evm",
-	MessageContracts: map[string]config.MessageProtocolConfig{
-		"0xd81545385803bCD83bd59f58Ba2d2c0562387F83": {
-			MessageFormat: config.TELEPORTER.String(),
-		},
-	},
-}
 
 func createRelayerKeys(blockchainIDs []ids.ID) []RelayerKey {
 	destinationsBlockchainIDs := set.NewSet[string](1) // just needs to be non-nil

--- a/database/json_file_storage_test.go
+++ b/database/json_file_storage_test.go
@@ -3,132 +3,152 @@
 
 package database
 
-// var validSourceBlockchainConfig = &config.SourceBlockchain{
-// 	RPCEndpoint:  "http://test.avax.network/ext/bc/C/rpc",
-// 	WSEndpoint:   "ws://test.avax.network/ext/bc/C/ws",
-// 	BlockchainID: "S4mMqUXe7vHsGiRAma6bv3CKnyaLssyAxmQ2KvFpX1KEvfFCD",
-// 	SubnetID:     "2TGBXcnwx5PqiXWiqxAKUaNSqDguXNh1mxnp82jui68hxJSZAx",
-// 	VM:           "evm",
-// 	MessageContracts: map[string]config.MessageProtocolConfig{
-// 		"0xd81545385803bCD83bd59f58Ba2d2c0562387F83": {
-// 			MessageFormat: config.TELEPORTER.String(),
-// 		},
-// 	},
-// }
+import (
+	"fmt"
+	"math/big"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
 
-// func populateSourceConfig(blockchainIDs []ids.ID) []*config.SourceBlockchain {
-// 	sourceBlockchains := make([]*config.SourceBlockchain, len(blockchainIDs))
-// 	for i, id := range blockchainIDs {
-// 		sourceBlockchains[i] = validSourceBlockchainConfig
-// 		sourceBlockchains[i].BlockchainID = id.String()
-// 	}
-// 	destinationsBlockchainIDs := set.NewSet[string](1) // just needs to be non-nil
-// 	destinationsBlockchainIDs.Add(ids.GenerateTestID().String())
-// 	sourceBlockchains[0].Validate(&destinationsBlockchainIDs)
-// 	return sourceBlockchains
-// }
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/awm-relayer/config"
+	"github.com/stretchr/testify/assert"
+)
+
+var validSourceBlockchainConfig = &config.SourceBlockchain{
+	RPCEndpoint:  "http://test.avax.network/ext/bc/C/rpc",
+	WSEndpoint:   "ws://test.avax.network/ext/bc/C/ws",
+	BlockchainID: "S4mMqUXe7vHsGiRAma6bv3CKnyaLssyAxmQ2KvFpX1KEvfFCD",
+	SubnetID:     "2TGBXcnwx5PqiXWiqxAKUaNSqDguXNh1mxnp82jui68hxJSZAx",
+	VM:           "evm",
+	MessageContracts: map[string]config.MessageProtocolConfig{
+		"0xd81545385803bCD83bd59f58Ba2d2c0562387F83": {
+			MessageFormat: config.TELEPORTER.String(),
+		},
+	},
+}
+
+func createRelayerKeys(blockchainIDs []ids.ID) []RelayerKey {
+	destinationsBlockchainIDs := set.NewSet[string](1) // just needs to be non-nil
+	destinationsBlockchainIDs.Add(ids.GenerateTestID().String())
+
+	var relayerKeys []RelayerKey
+	for _, blockchainID := range blockchainIDs {
+		for allowedDestination := range destinationsBlockchainIDs {
+			id, _ := ids.FromString(allowedDestination)
+			relayerKeys = append(relayerKeys, RelayerKey{
+				SourceBlockchainID:      blockchainID,
+				DestinationBlockchainID: id,
+			},
+			)
+		}
+	}
+	return relayerKeys
+}
 
 // Test that the JSON database can write and read to a single chain concurrently.
-// func TestConcurrentWriteReadSingleChain(t *testing.T) {
-// 	sourceBlockchains := populateSourceConfig(
-// 		[]ids.ID{
-// 			ids.GenerateTestID(),
-// 		},
-// 	)
-// 	jsonStorage := setupJsonStorage(t, sourceBlockchains)
+func TestConcurrentWriteReadSingleChain(t *testing.T) {
+	relayerKeys := createRelayerKeys(
+		[]ids.ID{
+			ids.GenerateTestID(),
+		},
+	)
+	jsonStorage := setupJsonStorage(t, relayerKeys)
 
-// 	// Test writing to the JSON database concurrently.
-// 	wg := sync.WaitGroup{}
-// 	for i := 0; i < 10; i++ {
-// 		wg.Add(1)
-// 		idx := i
-// 		go func() {
-// 			defer wg.Done()
-// 			testWrite(jsonStorage, sourceBlockchains[0].GetBlockchainID(), uint64(idx))
-// 		}()
-// 	}
-// 	wg.Wait()
+	// Test writing to the JSON database concurrently.
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		idx := i
+		go func() {
+			defer wg.Done()
+			testWrite(jsonStorage, relayerKeys[0], uint64(idx))
+		}()
+	}
+	wg.Wait()
 
-// 	// Write one final time to ensure that concurrent writes don't cause any issues.
-// 	finalTargetValue := uint64(11)
-// 	testWrite(jsonStorage, sourceBlockchains[0].GetBlockchainID(), finalTargetValue)
+	// Write one final time to ensure that concurrent writes don't cause any issues.
+	finalTargetValue := uint64(11)
+	testWrite(jsonStorage, relayerKeys[0], finalTargetValue)
 
-// 	latestProcessedBlockData, err := jsonStorage.Get(sourceBlockchains[0].GetBlockchainID(), []byte(LatestProcessedBlockKey))
-// 	if err != nil {
-// 		t.Fatalf("failed to retrieve from JSON storage. err: %v", err)
-// 	}
-// 	latestProcessedBlock, success := new(big.Int).SetString(string(latestProcessedBlockData), 10)
-// 	if !success {
-// 		t.Fatalf("failed to convert latest block to big.Int. err: %v", err)
-// 	}
-// 	assert.Equal(t, finalTargetValue, latestProcessedBlock.Uint64(), "latest processed block height is not correct.")
-// }
+	latestProcessedBlockData, err := jsonStorage.Get(relayerKeys[0].CalculateRelayerKey(), []byte(LatestProcessedBlockKey))
+	if err != nil {
+		t.Fatalf("failed to retrieve from JSON storage. err: %v", err)
+	}
+	latestProcessedBlock, success := new(big.Int).SetString(string(latestProcessedBlockData), 10)
+	if !success {
+		t.Fatalf("failed to convert latest block to big.Int. err: %v", err)
+	}
+	assert.Equal(t, finalTargetValue, latestProcessedBlock.Uint64(), "latest processed block height is not correct.")
+}
 
-// // Test that the JSON database can write and read from multiple chains concurrently. Write to any given chain are not concurrent.
-// func TestConcurrentWriteReadMultipleChains(t *testing.T) {
-// 	sourceBlockchains := populateSourceConfig(
-// 		[]ids.ID{
-// 			ids.GenerateTestID(),
-// 			ids.GenerateTestID(),
-// 			ids.GenerateTestID(),
-// 		},
-// 	)
-// 	jsonStorage := setupJsonStorage(t, sourceBlockchains)
+// Test that the JSON database can write and read from multiple chains concurrently. Write to any given chain are not concurrent.
+func TestConcurrentWriteReadMultipleChains(t *testing.T) {
+	relayerKeys := createRelayerKeys(
+		[]ids.ID{
+			ids.GenerateTestID(),
+			ids.GenerateTestID(),
+			ids.GenerateTestID(),
+		},
+	)
+	jsonStorage := setupJsonStorage(t, relayerKeys)
 
-// 	// Test writing to the JSON database concurrently.
-// 	wg := sync.WaitGroup{}
-// 	for i := 0; i < 3; i++ {
-// 		wg.Add(1)
-// 		index := i
-// 		go func() {
-// 			defer wg.Done()
-// 			testWrite(jsonStorage, sourceBlockchains[index].GetBlockchainID(), uint64(index))
-// 		}()
-// 	}
-// 	wg.Wait()
+	// Test writing to the JSON database concurrently.
+	wg := sync.WaitGroup{}
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		index := i
+		go func() {
+			defer wg.Done()
+			testWrite(jsonStorage, relayerKeys[index], uint64(index))
+		}()
+	}
+	wg.Wait()
 
-// 	// Write one final time to ensure that concurrent writes don't cause any issues.
-// 	finalTargetValue := uint64(3)
-// 	for _, sourceBlockchain := range sourceBlockchains {
-// 		testWrite(jsonStorage, sourceBlockchain.GetBlockchainID(), finalTargetValue)
-// 	}
+	// Write one final time to ensure that concurrent writes don't cause any issues.
+	finalTargetValue := uint64(3)
+	for _, relayerKey := range relayerKeys {
+		testWrite(jsonStorage, relayerKey, finalTargetValue)
+	}
 
-// 	for i, sourceBlockchain := range sourceBlockchains {
-// 		latestProcessedBlockData, err := jsonStorage.Get(sourceBlockchain.GetBlockchainID(), []byte(LatestProcessedBlockKey))
-// 		if err != nil {
-// 			t.Fatalf("failed to retrieve from JSON storage. networkID: %d err: %v", i, err)
-// 		}
-// 		latestProcessedBlock, success := new(big.Int).SetString(string(latestProcessedBlockData), 10)
-// 		if !success {
-// 			t.Fatalf("failed to convert latest block to big.Int. err: %v", err)
-// 		}
-// 		assert.Equal(t, finalTargetValue, latestProcessedBlock.Uint64(), fmt.Sprintf("latest processed block height is not correct. networkID: %d", i))
-// 	}
-// }
+	for i, relayerKey := range relayerKeys {
+		latestProcessedBlockData, err := jsonStorage.Get(relayerKey.CalculateRelayerKey(), []byte(LatestProcessedBlockKey))
+		if err != nil {
+			t.Fatalf("failed to retrieve from JSON storage. networkID: %d err: %v", i, err)
+		}
+		latestProcessedBlock, success := new(big.Int).SetString(string(latestProcessedBlockData), 10)
+		if !success {
+			t.Fatalf("failed to convert latest block to big.Int. err: %v", err)
+		}
+		assert.Equal(t, finalTargetValue, latestProcessedBlock.Uint64(), fmt.Sprintf("latest processed block height is not correct. networkID: %d", i))
+	}
+}
 
-// func setupJsonStorage(t *testing.T, sourceBlockchains []*config.SourceBlockchain) *JSONFileStorage {
-// 	logger := logging.NewLogger(
-// 		"awm-relayer-test",
-// 		logging.NewWrappedCore(
-// 			logging.Info,
-// 			os.Stdout,
-// 			logging.JSON.ConsoleEncoder(),
-// 		),
-// 	)
-// 	storageDir := t.TempDir()
+func setupJsonStorage(t *testing.T, relayerKeys []RelayerKey) *JSONFileStorage {
+	logger := logging.NewLogger(
+		"awm-relayer-test",
+		logging.NewWrappedCore(
+			logging.Info,
+			os.Stdout,
+			logging.JSON.ConsoleEncoder(),
+		),
+	)
+	storageDir := t.TempDir()
 
-// 	jsonStorage, err := NewJSONFileStorage(logger, storageDir, sourceBlockchains)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	return jsonStorage
-// }
+	jsonStorage, err := NewJSONFileStorage(logger, storageDir, relayerKeys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return jsonStorage
+}
 
-// func testWrite(storage *JSONFileStorage, blockchainID ids.ID, height uint64) {
-// 	fmt.Println(blockchainID, height)
-// 	err := storage.Put(blockchainID, []byte(LatestProcessedBlockKey), []byte(strconv.FormatUint(height, 10)))
-// 	if err != nil {
-// 		fmt.Printf("failed to put data: %v", err)
-// 		return
-// 	}
-// }
+func testWrite(storage *JSONFileStorage, relayerKey RelayerKey, height uint64) {
+	err := storage.Put(relayerKey.CalculateRelayerKey(), []byte(LatestProcessedBlockKey), []byte(strconv.FormatUint(height, 10)))
+	if err != nil {
+		fmt.Printf("failed to put data: %v", err)
+		return
+	}
+}

--- a/database/json_file_storage_test.go
+++ b/database/json_file_storage_test.go
@@ -4,18 +4,9 @@
 package database
 
 import (
-	"fmt"
-	"math/big"
-	"os"
-	"strconv"
-	"sync"
-	"testing"
-
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/awm-relayer/config"
-	"github.com/stretchr/testify/assert"
 )
 
 var validSourceBlockchainConfig = &config.SourceBlockchain{
@@ -44,106 +35,106 @@ func populateSourceConfig(blockchainIDs []ids.ID) []*config.SourceBlockchain {
 }
 
 // Test that the JSON database can write and read to a single chain concurrently.
-func TestConcurrentWriteReadSingleChain(t *testing.T) {
-	sourceBlockchains := populateSourceConfig(
-		[]ids.ID{
-			ids.GenerateTestID(),
-		},
-	)
-	jsonStorage := setupJsonStorage(t, sourceBlockchains)
+// func TestConcurrentWriteReadSingleChain(t *testing.T) {
+// 	sourceBlockchains := populateSourceConfig(
+// 		[]ids.ID{
+// 			ids.GenerateTestID(),
+// 		},
+// 	)
+// 	jsonStorage := setupJsonStorage(t, sourceBlockchains)
 
-	// Test writing to the JSON database concurrently.
-	wg := sync.WaitGroup{}
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		idx := i
-		go func() {
-			defer wg.Done()
-			testWrite(jsonStorage, sourceBlockchains[0].GetBlockchainID(), uint64(idx))
-		}()
-	}
-	wg.Wait()
+// 	// Test writing to the JSON database concurrently.
+// 	wg := sync.WaitGroup{}
+// 	for i := 0; i < 10; i++ {
+// 		wg.Add(1)
+// 		idx := i
+// 		go func() {
+// 			defer wg.Done()
+// 			testWrite(jsonStorage, sourceBlockchains[0].GetBlockchainID(), uint64(idx))
+// 		}()
+// 	}
+// 	wg.Wait()
 
-	// Write one final time to ensure that concurrent writes don't cause any issues.
-	finalTargetValue := uint64(11)
-	testWrite(jsonStorage, sourceBlockchains[0].GetBlockchainID(), finalTargetValue)
+// 	// Write one final time to ensure that concurrent writes don't cause any issues.
+// 	finalTargetValue := uint64(11)
+// 	testWrite(jsonStorage, sourceBlockchains[0].GetBlockchainID(), finalTargetValue)
 
-	latestProcessedBlockData, err := jsonStorage.Get(sourceBlockchains[0].GetBlockchainID(), []byte(LatestProcessedBlockKey))
-	if err != nil {
-		t.Fatalf("failed to retrieve from JSON storage. err: %v", err)
-	}
-	latestProcessedBlock, success := new(big.Int).SetString(string(latestProcessedBlockData), 10)
-	if !success {
-		t.Fatalf("failed to convert latest block to big.Int. err: %v", err)
-	}
-	assert.Equal(t, finalTargetValue, latestProcessedBlock.Uint64(), "latest processed block height is not correct.")
-}
+// 	latestProcessedBlockData, err := jsonStorage.Get(sourceBlockchains[0].GetBlockchainID(), []byte(LatestProcessedBlockKey))
+// 	if err != nil {
+// 		t.Fatalf("failed to retrieve from JSON storage. err: %v", err)
+// 	}
+// 	latestProcessedBlock, success := new(big.Int).SetString(string(latestProcessedBlockData), 10)
+// 	if !success {
+// 		t.Fatalf("failed to convert latest block to big.Int. err: %v", err)
+// 	}
+// 	assert.Equal(t, finalTargetValue, latestProcessedBlock.Uint64(), "latest processed block height is not correct.")
+// }
 
-// Test that the JSON database can write and read from multiple chains concurrently. Write to any given chain are not concurrent.
-func TestConcurrentWriteReadMultipleChains(t *testing.T) {
-	sourceBlockchains := populateSourceConfig(
-		[]ids.ID{
-			ids.GenerateTestID(),
-			ids.GenerateTestID(),
-			ids.GenerateTestID(),
-		},
-	)
-	jsonStorage := setupJsonStorage(t, sourceBlockchains)
+// // Test that the JSON database can write and read from multiple chains concurrently. Write to any given chain are not concurrent.
+// func TestConcurrentWriteReadMultipleChains(t *testing.T) {
+// 	sourceBlockchains := populateSourceConfig(
+// 		[]ids.ID{
+// 			ids.GenerateTestID(),
+// 			ids.GenerateTestID(),
+// 			ids.GenerateTestID(),
+// 		},
+// 	)
+// 	jsonStorage := setupJsonStorage(t, sourceBlockchains)
 
-	// Test writing to the JSON database concurrently.
-	wg := sync.WaitGroup{}
-	for i := 0; i < 3; i++ {
-		wg.Add(1)
-		index := i
-		go func() {
-			defer wg.Done()
-			testWrite(jsonStorage, sourceBlockchains[index].GetBlockchainID(), uint64(index))
-		}()
-	}
-	wg.Wait()
+// 	// Test writing to the JSON database concurrently.
+// 	wg := sync.WaitGroup{}
+// 	for i := 0; i < 3; i++ {
+// 		wg.Add(1)
+// 		index := i
+// 		go func() {
+// 			defer wg.Done()
+// 			testWrite(jsonStorage, sourceBlockchains[index].GetBlockchainID(), uint64(index))
+// 		}()
+// 	}
+// 	wg.Wait()
 
-	// Write one final time to ensure that concurrent writes don't cause any issues.
-	finalTargetValue := uint64(3)
-	for _, sourceBlockchain := range sourceBlockchains {
-		testWrite(jsonStorage, sourceBlockchain.GetBlockchainID(), finalTargetValue)
-	}
+// 	// Write one final time to ensure that concurrent writes don't cause any issues.
+// 	finalTargetValue := uint64(3)
+// 	for _, sourceBlockchain := range sourceBlockchains {
+// 		testWrite(jsonStorage, sourceBlockchain.GetBlockchainID(), finalTargetValue)
+// 	}
 
-	for i, sourceBlockchain := range sourceBlockchains {
-		latestProcessedBlockData, err := jsonStorage.Get(sourceBlockchain.GetBlockchainID(), []byte(LatestProcessedBlockKey))
-		if err != nil {
-			t.Fatalf("failed to retrieve from JSON storage. networkID: %d err: %v", i, err)
-		}
-		latestProcessedBlock, success := new(big.Int).SetString(string(latestProcessedBlockData), 10)
-		if !success {
-			t.Fatalf("failed to convert latest block to big.Int. err: %v", err)
-		}
-		assert.Equal(t, finalTargetValue, latestProcessedBlock.Uint64(), fmt.Sprintf("latest processed block height is not correct. networkID: %d", i))
-	}
-}
+// 	for i, sourceBlockchain := range sourceBlockchains {
+// 		latestProcessedBlockData, err := jsonStorage.Get(sourceBlockchain.GetBlockchainID(), []byte(LatestProcessedBlockKey))
+// 		if err != nil {
+// 			t.Fatalf("failed to retrieve from JSON storage. networkID: %d err: %v", i, err)
+// 		}
+// 		latestProcessedBlock, success := new(big.Int).SetString(string(latestProcessedBlockData), 10)
+// 		if !success {
+// 			t.Fatalf("failed to convert latest block to big.Int. err: %v", err)
+// 		}
+// 		assert.Equal(t, finalTargetValue, latestProcessedBlock.Uint64(), fmt.Sprintf("latest processed block height is not correct. networkID: %d", i))
+// 	}
+// }
 
-func setupJsonStorage(t *testing.T, sourceBlockchains []*config.SourceBlockchain) *JSONFileStorage {
-	logger := logging.NewLogger(
-		"awm-relayer-test",
-		logging.NewWrappedCore(
-			logging.Info,
-			os.Stdout,
-			logging.JSON.ConsoleEncoder(),
-		),
-	)
-	storageDir := t.TempDir()
+// func setupJsonStorage(t *testing.T, sourceBlockchains []*config.SourceBlockchain) *JSONFileStorage {
+// 	logger := logging.NewLogger(
+// 		"awm-relayer-test",
+// 		logging.NewWrappedCore(
+// 			logging.Info,
+// 			os.Stdout,
+// 			logging.JSON.ConsoleEncoder(),
+// 		),
+// 	)
+// 	storageDir := t.TempDir()
 
-	jsonStorage, err := NewJSONFileStorage(logger, storageDir, sourceBlockchains)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return jsonStorage
-}
+// 	jsonStorage, err := NewJSONFileStorage(logger, storageDir, sourceBlockchains)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	return jsonStorage
+// }
 
-func testWrite(storage *JSONFileStorage, blockchainID ids.ID, height uint64) {
-	fmt.Println(blockchainID, height)
-	err := storage.Put(blockchainID, []byte(LatestProcessedBlockKey), []byte(strconv.FormatUint(height, 10)))
-	if err != nil {
-		fmt.Printf("failed to put data: %v", err)
-		return
-	}
-}
+// func testWrite(storage *JSONFileStorage, blockchainID ids.ID, height uint64) {
+// 	fmt.Println(blockchainID, height)
+// 	err := storage.Put(blockchainID, []byte(LatestProcessedBlockKey), []byte(strconv.FormatUint(height, 10)))
+// 	if err != nil {
+// 		fmt.Printf("failed to put data: %v", err)
+// 		return
+// 	}
+// }

--- a/database/json_file_storage_test.go
+++ b/database/json_file_storage_test.go
@@ -60,7 +60,7 @@ func TestConcurrentWriteReadSingleChain(t *testing.T) {
 	finalTargetValue := uint64(11)
 	testWrite(jsonStorage, relayerKeys[0], finalTargetValue)
 
-	latestProcessedBlockData, err := jsonStorage.Get(relayerKeys[0].GetKey(), []byte(LatestProcessedBlockKey))
+	latestProcessedBlockData, err := jsonStorage.Get(relayerKeys[0].GetKey(), LatestProcessedBlockKey)
 	if err != nil {
 		t.Fatalf("failed to retrieve from JSON storage. err: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestConcurrentWriteReadMultipleChains(t *testing.T) {
 	}
 
 	for i, relayerKey := range relayerKeys {
-		latestProcessedBlockData, err := jsonStorage.Get(relayerKey.GetKey(), []byte(LatestProcessedBlockKey))
+		latestProcessedBlockData, err := jsonStorage.Get(relayerKey.GetKey(), LatestProcessedBlockKey)
 		if err != nil {
 			t.Fatalf("failed to retrieve from JSON storage. networkID: %d err: %v", i, err)
 		}
@@ -132,7 +132,7 @@ func setupJsonStorage(t *testing.T, relayerKeys []RelayerKey) *JSONFileStorage {
 }
 
 func testWrite(storage *JSONFileStorage, relayerKey RelayerKey, height uint64) {
-	err := storage.Put(relayerKey.GetKey(), []byte(LatestProcessedBlockKey), []byte(strconv.FormatUint(height, 10)))
+	err := storage.Put(relayerKey.GetKey(), LatestProcessedBlockKey, []byte(strconv.FormatUint(height, 10)))
 	if err != nil {
 		fmt.Printf("failed to put data: %v", err)
 		return

--- a/database/json_file_storage_test.go
+++ b/database/json_file_storage_test.go
@@ -60,7 +60,7 @@ func TestConcurrentWriteReadSingleChain(t *testing.T) {
 	finalTargetValue := uint64(11)
 	testWrite(jsonStorage, relayerKeys[0], finalTargetValue)
 
-	latestProcessedBlockData, err := jsonStorage.Get(relayerKeys[0].CalculateRelayerKey(), []byte(LatestProcessedBlockKey))
+	latestProcessedBlockData, err := jsonStorage.Get(relayerKeys[0].GetKey(), []byte(LatestProcessedBlockKey))
 	if err != nil {
 		t.Fatalf("failed to retrieve from JSON storage. err: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestConcurrentWriteReadMultipleChains(t *testing.T) {
 	}
 
 	for i, relayerKey := range relayerKeys {
-		latestProcessedBlockData, err := jsonStorage.Get(relayerKey.CalculateRelayerKey(), []byte(LatestProcessedBlockKey))
+		latestProcessedBlockData, err := jsonStorage.Get(relayerKey.GetKey(), []byte(LatestProcessedBlockKey))
 		if err != nil {
 			t.Fatalf("failed to retrieve from JSON storage. networkID: %d err: %v", i, err)
 		}
@@ -132,7 +132,7 @@ func setupJsonStorage(t *testing.T, relayerKeys []RelayerKey) *JSONFileStorage {
 }
 
 func testWrite(storage *JSONFileStorage, relayerKey RelayerKey, height uint64) {
-	err := storage.Put(relayerKey.CalculateRelayerKey(), []byte(LatestProcessedBlockKey), []byte(strconv.FormatUint(height, 10)))
+	err := storage.Put(relayerKey.GetKey(), []byte(LatestProcessedBlockKey), []byte(strconv.FormatUint(height, 10)))
 	if err != nil {
 		fmt.Printf("failed to put data: %v", err)
 		return

--- a/database/mocks/mock_database.go
+++ b/database/mocks/mock_database.go
@@ -40,30 +40,30 @@ func (m *MockRelayerDatabase) EXPECT() *MockRelayerDatabaseMockRecorder {
 }
 
 // Get mocks base method.
-func (m *MockRelayerDatabase) Get(relayerKey common.Hash, dataKey database.DataKey) ([]byte, error) {
+func (m *MockRelayerDatabase) Get(relayerID common.Hash, key database.DataKey) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", relayerKey, dataKey)
+	ret := m.ctrl.Call(m, "Get", relayerID, key)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockRelayerDatabaseMockRecorder) Get(relayerKey, dataKey any) *gomock.Call {
+func (mr *MockRelayerDatabaseMockRecorder) Get(relayerID, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockRelayerDatabase)(nil).Get), relayerKey, dataKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockRelayerDatabase)(nil).Get), relayerID, key)
 }
 
 // Put mocks base method.
-func (m *MockRelayerDatabase) Put(relayerKey common.Hash, dataKey database.DataKey, value []byte) error {
+func (m *MockRelayerDatabase) Put(relayerID common.Hash, key database.DataKey, value []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Put", relayerKey, dataKey, value)
+	ret := m.ctrl.Call(m, "Put", relayerID, key, value)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockRelayerDatabaseMockRecorder) Put(relayerKey, dataKey, value any) *gomock.Call {
+func (mr *MockRelayerDatabaseMockRecorder) Put(relayerID, key, value any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockRelayerDatabase)(nil).Put), relayerKey, dataKey, value)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockRelayerDatabase)(nil).Put), relayerID, key, value)
 }

--- a/database/mocks/mock_database.go
+++ b/database/mocks/mock_database.go
@@ -11,6 +11,7 @@ package mocks
 import (
 	reflect "reflect"
 
+	database "github.com/ava-labs/awm-relayer/database"
 	common "github.com/ethereum/go-ethereum/common"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -39,30 +40,30 @@ func (m *MockRelayerDatabase) EXPECT() *MockRelayerDatabaseMockRecorder {
 }
 
 // Get mocks base method.
-func (m *MockRelayerDatabase) Get(relayerKey common.Hash, key []byte) ([]byte, error) {
+func (m *MockRelayerDatabase) Get(relayerKey common.Hash, dataKey database.DataKey) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", relayerKey, key)
+	ret := m.ctrl.Call(m, "Get", relayerKey, dataKey)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockRelayerDatabaseMockRecorder) Get(relayerKey, key any) *gomock.Call {
+func (mr *MockRelayerDatabaseMockRecorder) Get(relayerKey, dataKey any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockRelayerDatabase)(nil).Get), relayerKey, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockRelayerDatabase)(nil).Get), relayerKey, dataKey)
 }
 
 // Put mocks base method.
-func (m *MockRelayerDatabase) Put(relayerKey common.Hash, key, value []byte) error {
+func (m *MockRelayerDatabase) Put(relayerKey common.Hash, dataKey database.DataKey, value []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Put", relayerKey, key, value)
+	ret := m.ctrl.Call(m, "Put", relayerKey, dataKey, value)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockRelayerDatabaseMockRecorder) Put(relayerKey, key, value any) *gomock.Call {
+func (mr *MockRelayerDatabaseMockRecorder) Put(relayerKey, dataKey, value any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockRelayerDatabase)(nil).Put), relayerKey, key, value)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockRelayerDatabase)(nil).Put), relayerKey, dataKey, value)
 }

--- a/database/mocks/mock_database.go
+++ b/database/mocks/mock_database.go
@@ -11,7 +11,7 @@ package mocks
 import (
 	reflect "reflect"
 
-	ids "github.com/ava-labs/avalanchego/ids"
+	common "github.com/ethereum/go-ethereum/common"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -39,30 +39,30 @@ func (m *MockRelayerDatabase) EXPECT() *MockRelayerDatabaseMockRecorder {
 }
 
 // Get mocks base method.
-func (m *MockRelayerDatabase) Get(blockchainID ids.ID, key []byte) ([]byte, error) {
+func (m *MockRelayerDatabase) Get(relayerKey common.Hash, key []byte) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", blockchainID, key)
+	ret := m.ctrl.Call(m, "Get", relayerKey, key)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockRelayerDatabaseMockRecorder) Get(blockchainID, key any) *gomock.Call {
+func (mr *MockRelayerDatabaseMockRecorder) Get(relayerKey, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockRelayerDatabase)(nil).Get), blockchainID, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockRelayerDatabase)(nil).Get), relayerKey, key)
 }
 
 // Put mocks base method.
-func (m *MockRelayerDatabase) Put(blockchainID ids.ID, key, value []byte) error {
+func (m *MockRelayerDatabase) Put(relayerKey common.Hash, key, value []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Put", blockchainID, key, value)
+	ret := m.ctrl.Call(m, "Put", relayerKey, key, value)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockRelayerDatabaseMockRecorder) Put(blockchainID, key, value any) *gomock.Call {
+func (mr *MockRelayerDatabaseMockRecorder) Put(relayerKey, key, value any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockRelayerDatabase)(nil).Put), blockchainID, key, value)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockRelayerDatabase)(nil).Put), relayerKey, key, value)
 }

--- a/main/main.go
+++ b/main/main.go
@@ -174,7 +174,7 @@ func main() {
 	}
 
 	// Initialize the database
-	db, err := database.NewJSONFileStorage(logger, cfg)
+	db, err := database.NewJSONFileStorage(logger, cfg.StorageLocation, cfg.GetAllRelayerKeys())
 	if err != nil {
 		logger.Error(
 			"Failed to create database",

--- a/main/main.go
+++ b/main/main.go
@@ -174,7 +174,7 @@ func main() {
 	}
 
 	// Initialize the database
-	db, err := database.NewJSONFileStorage(logger, cfg.StorageLocation, cfg.GetAllRelayerKeys())
+	db, err := database.NewJSONFileStorage(logger, cfg.StorageLocation, database.GetConfigRelayerKeys(&cfg))
 	if err != nil {
 		logger.Error(
 			"Failed to create database",

--- a/main/main.go
+++ b/main/main.go
@@ -147,7 +147,7 @@ func main() {
 		log.Fatalln(http.ListenAndServe(fmt.Sprintf(":%d", cfg.APIPort), nil))
 	}()
 
-	startMetricsServer(logger, gatherer, uint32(cfg.MetricsPort))
+	startMetricsServer(logger, gatherer, cfg.MetricsPort)
 
 	metrics, err := relayer.NewMessageRelayerMetrics(registerer)
 	if err != nil {
@@ -302,12 +302,12 @@ func runRelayer(
 	return relayer.ProcessLogs(ctx)
 }
 
-func startMetricsServer(logger logging.Logger, gatherer prometheus.Gatherer, port uint32) {
+func startMetricsServer(logger logging.Logger, gatherer prometheus.Gatherer, port uint16) {
 	http.Handle("/metrics", promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{}))
 
 	go func() {
 		logger.Info("starting metrics server...",
-			zap.Uint32("port", port))
+			zap.Uint16("port", port))
 		log.Fatalln(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
 	}()
 }

--- a/main/main.go
+++ b/main/main.go
@@ -226,7 +226,7 @@ func main() {
 				messageCreator,
 				health,
 				manualWarpMessages[blockchainID],
-				cfg,
+				&cfg,
 			)
 		})
 	}
@@ -251,7 +251,7 @@ func runRelayer(
 	messageCreator message.Creator,
 	relayerHealth *atomic.Bool,
 	manualWarpMessages []*vmtypes.WarpLogInfo,
-	cfg config.Config,
+	cfg *config.Config,
 ) error {
 	logger.Info(
 		"Creating relayer",

--- a/main/main.go
+++ b/main/main.go
@@ -32,11 +32,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const (
-	defaultApiPort     = 8080
-	defaultMetricsPort = 9090
-)
-
 func main() {
 	fs := config.BuildFlagSet()
 	v, err := config.BuildViper(fs, os.Args[1:])
@@ -149,10 +144,10 @@ func main() {
 
 	// start the health check server
 	go func() {
-		log.Fatalln(http.ListenAndServe(fmt.Sprintf(":%d", defaultApiPort), nil))
+		log.Fatalln(http.ListenAndServe(fmt.Sprintf(":%d", cfg.APIPort), nil))
 	}()
 
-	startMetricsServer(logger, gatherer, defaultMetricsPort)
+	startMetricsServer(logger, gatherer, uint32(cfg.MetricsPort))
 
 	metrics, err := relayer.NewMessageRelayerMetrics(registerer)
 	if err != nil {

--- a/main/main.go
+++ b/main/main.go
@@ -169,7 +169,7 @@ func main() {
 	}
 
 	// Initialize the database
-	db, err := database.NewJSONFileStorage(logger, cfg.StorageLocation, database.GetConfigRelayerKeys(&cfg))
+	db, err := database.NewJSONFileStorage(logger, cfg.StorageLocation, database.GetConfigRelayerIDs(&cfg))
 	if err != nil {
 		logger.Error(
 			"Failed to create database",

--- a/main/main.go
+++ b/main/main.go
@@ -174,7 +174,7 @@ func main() {
 	}
 
 	// Initialize the database
-	db, err := database.NewJSONFileStorage(logger, cfg.StorageLocation, cfg.SourceBlockchains)
+	db, err := database.NewJSONFileStorage(logger, cfg)
 	if err != nil {
 		logger.Error(
 			"Failed to create database",

--- a/messages/message_manager.go
+++ b/messages/message_manager.go
@@ -32,8 +32,10 @@ type MessageManager interface {
 	// GetDestinationBlockchainID returns the destination chain ID of the destination chain for the given message
 	GetDestinationBlockchainID(unsignedMessage *warp.UnsignedMessage) (ids.ID, error)
 
+	// GetOriginSenderAddress returns the address of the sender on the origin chain
 	GetOriginSenderAddress(unsignedMessage *warp.UnsignedMessage) (common.Address, error)
 
+	// GetDestinationAddress returns the address of the recipient on the destination chain
 	GetDestinationAddress(unsignedMessage *warp.UnsignedMessage) (common.Address, error)
 }
 

--- a/messages/message_manager.go
+++ b/messages/message_manager.go
@@ -31,6 +31,10 @@ type MessageManager interface {
 
 	// GetDestinationBlockchainID returns the destination chain ID of the destination chain for the given message
 	GetDestinationBlockchainID(unsignedMessage *warp.UnsignedMessage) (ids.ID, error)
+
+	GetOriginSenderAddress(unsignedMessage *warp.UnsignedMessage) (common.Address, error)
+
+	GetDestinationAddress(unsignedMessage *warp.UnsignedMessage) (common.Address, error)
 }
 
 // NewMessageManager constructs a MessageManager for a particular message protocol, defined by the message protocol address and config

--- a/messages/off-chain-registry/message_manager.go
+++ b/messages/off-chain-registry/message_manager.go
@@ -173,7 +173,15 @@ func (m *messageManager) GetDestinationBlockchainID(unsignedMessage *warp.Unsign
 }
 
 func (m *messageManager) GetOriginSenderAddress(unsignedMessage *warp.UnsignedMessage) (common.Address, error) {
-	return OffChainRegistrySourceAddress, nil
+	addressedPayload, err := warpPayload.ParseAddressedCall(unsignedMessage.Payload)
+	if err != nil {
+		m.logger.Error(
+			"Failed parsing addressed payload",
+			zap.Error(err),
+		)
+		return common.Address{}, err
+	}
+	return common.BytesToAddress(addressedPayload.SourceAddress), nil
 }
 
 func (m *messageManager) GetDestinationAddress(unsignedMessage *warp.UnsignedMessage) (common.Address, error) {

--- a/messages/off-chain-registry/message_manager.go
+++ b/messages/off-chain-registry/message_manager.go
@@ -171,3 +171,11 @@ func (m *messageManager) SendMessage(signedMessage *warp.Message, destinationBlo
 func (m *messageManager) GetDestinationBlockchainID(unsignedMessage *warp.UnsignedMessage) (ids.ID, error) {
 	return unsignedMessage.SourceChainID, nil
 }
+
+func (m *messageManager) GetOriginSenderAddress(unsignedMessage *warp.UnsignedMessage) (common.Address, error) {
+	return OffChainRegistrySourceAddress, nil
+}
+
+func (m *messageManager) GetDestinationAddress(unsignedMessage *warp.UnsignedMessage) (common.Address, error) {
+	return m.registryAddress, nil
+}

--- a/messages/teleporter/message_manager.go
+++ b/messages/teleporter/message_manager.go
@@ -93,15 +93,11 @@ func (m *messageManager) GetDestinationBlockchainID(unsignedMessage *warp.Unsign
 	teleporterMessage, err := m.parseTeleporterMessage(unsignedMessage)
 	if err != nil {
 		m.logger.Error(
-			"Failed get teleporter message.",
+			"Failed to parse teleporter message.",
 			zap.String("warpMessageID", unsignedMessage.ID().String()),
 		)
 		return ids.ID{}, err
 	}
-
-	// Cache the message so it can be reused in SendMessage
-	m.teleporterMessageCache.Put(unsignedMessage.ID(), teleporterMessage)
-
 	return teleporterMessage.DestinationBlockchainID, nil
 }
 
@@ -109,12 +105,11 @@ func (m *messageManager) GetOriginSenderAddress(unsignedMessage *warp.UnsignedMe
 	teleporterMessage, err := m.parseTeleporterMessage(unsignedMessage)
 	if err != nil {
 		m.logger.Error(
-			"Failed get teleporter message.",
+			"Failed to parse teleporter message.",
 			zap.String("warpMessageID", unsignedMessage.ID().String()),
 		)
 		return common.Address{}, err
 	}
-	m.teleporterMessageCache.Put(unsignedMessage.ID(), teleporterMessage)
 	return teleporterMessage.OriginSenderAddress, nil
 }
 
@@ -122,12 +117,11 @@ func (m *messageManager) GetDestinationAddress(unsignedMessage *warp.UnsignedMes
 	teleporterMessage, err := m.parseTeleporterMessage(unsignedMessage)
 	if err != nil {
 		m.logger.Error(
-			"Failed get teleporter message.",
+			"Failed to parse teleporter message.",
 			zap.String("warpMessageID", unsignedMessage.ID().String()),
 		)
 		return common.Address{}, err
 	}
-	m.teleporterMessageCache.Put(unsignedMessage.ID(), teleporterMessage)
 	return teleporterMessage.DestinationAddress, nil
 }
 
@@ -194,8 +188,6 @@ func (m *messageManager) ShouldSendMessage(unsignedMessage *warp.UnsignedMessage
 		return false, nil
 	}
 
-	// Cache the message so it can be reused in SendMessage
-	m.teleporterMessageCache.Put(unsignedMessage.ID(), teleporterMessage)
 	return true, nil
 }
 
@@ -313,6 +305,7 @@ func (m *messageManager) parseTeleporterMessage(unsignedMessage *warp.UnsignedMe
 			)
 			return nil, err
 		}
+		m.teleporterMessageCache.Put(unsignedMessage.ID(), teleporterMessage)
 	}
 	return teleporterMessage, nil
 }

--- a/messages/teleporter/message_manager.go
+++ b/messages/teleporter/message_manager.go
@@ -105,6 +105,32 @@ func (m *messageManager) GetDestinationBlockchainID(unsignedMessage *warp.Unsign
 	return teleporterMessage.DestinationBlockchainID, nil
 }
 
+func (m *messageManager) GetOriginSenderAddress(unsignedMessage *warp.UnsignedMessage) (common.Address, error) {
+	teleporterMessage, err := m.parseTeleporterMessage(unsignedMessage)
+	if err != nil {
+		m.logger.Error(
+			"Failed get teleporter message.",
+			zap.String("warpMessageID", unsignedMessage.ID().String()),
+		)
+		return common.Address{}, err
+	}
+	m.teleporterMessageCache.Put(unsignedMessage.ID(), teleporterMessage)
+	return teleporterMessage.OriginSenderAddress, nil
+}
+
+func (m *messageManager) GetDestinationAddress(unsignedMessage *warp.UnsignedMessage) (common.Address, error) {
+	teleporterMessage, err := m.parseTeleporterMessage(unsignedMessage)
+	if err != nil {
+		m.logger.Error(
+			"Failed get teleporter message.",
+			zap.String("warpMessageID", unsignedMessage.ID().String()),
+		)
+		return common.Address{}, err
+	}
+	m.teleporterMessageCache.Put(unsignedMessage.ID(), teleporterMessage)
+	return teleporterMessage.DestinationAddress, nil
+}
+
 // ShouldSendMessage returns true if the message should be sent to the destination chain
 func (m *messageManager) ShouldSendMessage(unsignedMessage *warp.UnsignedMessage, destinationBlockchainID ids.ID) (bool, error) {
 	teleporterMessage, err := m.parseTeleporterMessage(unsignedMessage)

--- a/relayer/message_relayer.go
+++ b/relayer/message_relayer.go
@@ -61,14 +61,14 @@ type messageRelayer struct {
 	originSenderAddress     common.Address
 	destinationAddress      common.Address
 	signingSubnetID         ids.ID
-	relayerKey              config.RelayerKey
+	relayerKey              database.RelayerKey
 	warpQuorum              config.WarpQuorum
 	db                      database.RelayerDatabase
 }
 
 func newMessageRelayer(
 	relayer *Relayer,
-	relayerKey config.RelayerKey,
+	relayerKey database.RelayerKey,
 	db database.RelayerDatabase,
 ) (*messageRelayer, error) {
 	quorum, err := relayer.globalConfig.GetWarpQuorum(relayerKey.DestinationBlockchainID)
@@ -347,6 +347,7 @@ func (r *messageRelayer) createSignedMessageAppRequest(unsignedMessage *avalanch
 		if responsesExpected > 0 {
 			// Handle the responses. For each response, we need to call response.OnFinishedHandling() exactly once.
 			// Wrap the loop body in an anonymous function so that we do so on each loop iteration
+			// TODO: In order to run this concurrently, we need to route to each message relayer from the relayer responseChan
 			for response := range r.relayer.responseChan {
 				r.relayer.logger.Debug(
 					"Processing response from node",

--- a/relayer/message_relayer.go
+++ b/relayer/message_relayer.go
@@ -607,7 +607,7 @@ func (r *messageRelayer) aggregateSignatures(signatureMap map[int]blsSignatureBu
 //     we return the chain head.
 func (r *messageRelayer) calculateStartingBlockHeight(processHistoricalBlocksFromHeight uint64) (uint64, error) {
 	latestProcessedBlock, err := r.getLatestProcessedBlockHeight()
-	if errors.Is(err, database.ErrChainNotFound) || errors.Is(err, database.ErrKeyNotFound) {
+	if database.IsKeyNotFoundError(err) {
 		// The database does not contain the latest processed block data for the chain,
 		// use the configured process-historical-blocks-from-height instead.
 		// If process-historical-blocks-from-height was not configured, start from the chain head.
@@ -710,7 +710,7 @@ func (r *messageRelayer) storeLatestBlockHeight(height uint64) error {
 	// First, check that the stored height is less than the current block height
 	// This is necessary because the relayer may be processing blocks out of order on startup
 	latestProcessedBlock, err := r.getLatestProcessedBlockHeight()
-	if err != nil && !errors.Is(err, database.ErrChainNotFound) && !errors.Is(err, database.ErrKeyNotFound) {
+	if err != nil && !database.IsKeyNotFoundError(err) {
 		r.logger.Error(
 			"Encountered an unknown error while getting latest processed block from database",
 			zap.String("relayerKey", r.relayerKey.CalculateRelayerKey().String()),

--- a/relayer/message_relayer.go
+++ b/relayer/message_relayer.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ava-labs/subnet-evm/ethclient"
 	msg "github.com/ava-labs/subnet-evm/plugin/evm/message"
 	warpBackend "github.com/ava-labs/subnet-evm/warp"
-	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
 )
 
@@ -64,8 +63,6 @@ type messageRelayer struct {
 	responseChan            chan message.InboundMessage
 	sourceBlockchain        config.SourceBlockchain
 	destinationBlockchainID ids.ID
-	originSenderAddress     common.Address
-	destinationAddress      common.Address
 	signingSubnetID         ids.ID
 	relayerKey              database.RelayerKey
 	warpQuorum              config.WarpQuorum
@@ -108,8 +105,6 @@ func newMessageRelayer(
 		responseChan:            responseChan,
 		sourceBlockchain:        sourceBlockchain,
 		destinationBlockchainID: relayerKey.DestinationBlockchainID,
-		originSenderAddress:     relayerKey.OriginSenderAddress,
-		destinationAddress:      relayerKey.DestinationAddress,
 		relayerKey:              relayerKey,
 		signingSubnetID:         signingSubnet,
 		warpQuorum:              quorum,

--- a/relayer/message_relayer.go
+++ b/relayer/message_relayer.go
@@ -684,7 +684,7 @@ func (r *messageRelayer) setProcessedBlockHeightToLatest() (uint64, error) {
 // because it is updated as soon as a single message from that block is relayed,
 // and there may be multiple message in the same block.
 func (r *messageRelayer) getLatestProcessedBlockHeight() (uint64, error) {
-	latestProcessedBlockData, err := r.db.Get(r.relayerKey.GetKey(), []byte(database.LatestProcessedBlockKey))
+	latestProcessedBlockData, err := r.db.Get(r.relayerKey.GetKey(), database.LatestProcessedBlockKey)
 	if err != nil {
 		return 0, err
 	}
@@ -697,7 +697,7 @@ func (r *messageRelayer) getLatestProcessedBlockHeight() (uint64, error) {
 
 // Store the block height in the database. Does not check against the current latest processed block height.
 func (r *messageRelayer) storeBlockHeight(height uint64) error {
-	return r.db.Put(r.relayerKey.GetKey(), []byte(database.LatestProcessedBlockKey), []byte(strconv.FormatUint(height, 10)))
+	return r.db.Put(r.relayerKey.GetKey(), database.LatestProcessedBlockKey, []byte(strconv.FormatUint(height, 10)))
 }
 
 // Stores the block height in the database if it is greater than the current latest processed block height.

--- a/relayer/message_relayer.go
+++ b/relayer/message_relayer.go
@@ -117,7 +117,14 @@ func newMessageRelayer(
 	}, nil
 }
 
-func (r *messageRelayer) relayMessage(unsignedMessage *avalancheWarp.UnsignedMessage, requestID uint32, messageManager messages.MessageManager, useAppRequestNetwork bool) error {
+func (r *messageRelayer) relayMessage(
+	unsignedMessage *avalancheWarp.UnsignedMessage,
+	requestID uint32,
+	messageManager messages.MessageManager,
+	storeProcessedHeight bool,
+	blockNumber uint64,
+	useAppRequestNetwork bool,
+) error {
 	shouldSend, err := messageManager.ShouldSendMessage(unsignedMessage, r.destinationBlockchainID)
 	if err != nil {
 		r.logger.Error(
@@ -176,7 +183,13 @@ func (r *messageRelayer) relayMessage(unsignedMessage *avalancheWarp.UnsignedMes
 		zap.String("destinationBlockchainID", r.destinationBlockchainID.String()),
 	)
 	r.incSuccessfulRelayMessageCount()
-	return nil
+
+	if !storeProcessedHeight {
+		return nil
+	}
+
+	// Update the database with the latest processed block height
+	return r.storeLatestBlockHeight(blockNumber)
 }
 
 // createSignedMessage fetches the signed Warp message from the source chain via RPC.

--- a/relayer/message_relayer.go
+++ b/relayer/message_relayer.go
@@ -614,7 +614,7 @@ func (r *messageRelayer) calculateStartingBlockHeight(processHistoricalBlocksFro
 		// Otherwise, we've encountered an unknown database error
 		r.logger.Error(
 			"failed to get latest block from database",
-			zap.String("relayerKey", r.relayerKey.CalculateRelayerKey().String()),
+			zap.String("relayerKey", r.relayerKey.GetKey().String()),
 			zap.Error(err),
 		)
 		return 0, err
@@ -625,7 +625,7 @@ func (r *messageRelayer) calculateStartingBlockHeight(processHistoricalBlocksFro
 	if latestProcessedBlock > processHistoricalBlocksFromHeight {
 		r.logger.Info(
 			"Processing historical blocks from the latest processed block in the DB",
-			zap.String("relayerKey", r.relayerKey.CalculateRelayerKey().String()),
+			zap.String("relayerKey", r.relayerKey.GetKey().String()),
 			zap.Uint64("latestProcessedBlock", latestProcessedBlock),
 		)
 		return latestProcessedBlock, nil
@@ -633,7 +633,7 @@ func (r *messageRelayer) calculateStartingBlockHeight(processHistoricalBlocksFro
 	// Otherwise, return the configured start block height
 	r.logger.Info(
 		"Processing historical blocks from the configured start block height",
-		zap.String("relayerKey", r.relayerKey.CalculateRelayerKey().String()),
+		zap.String("relayerKey", r.relayerKey.GetKey().String()),
 		zap.Uint64("processHistoricalBlocksFromHeight", processHistoricalBlocksFromHeight),
 	)
 	return processHistoricalBlocksFromHeight, nil
@@ -663,7 +663,7 @@ func (r *messageRelayer) setProcessedBlockHeightToLatest() (uint64, error) {
 
 	r.logger.Info(
 		"Updating latest processed block in database",
-		zap.String("relayerKey", r.relayerKey.CalculateRelayerKey().String()),
+		zap.String("relayerKey", r.relayerKey.GetKey().String()),
 		zap.Uint64("latestBlock", latestBlock),
 	)
 
@@ -671,7 +671,7 @@ func (r *messageRelayer) setProcessedBlockHeightToLatest() (uint64, error) {
 	if err != nil {
 		r.logger.Error(
 			fmt.Sprintf("failed to put %s into database", database.LatestProcessedBlockKey),
-			zap.String("relayerKey", r.relayerKey.CalculateRelayerKey().String()),
+			zap.String("relayerKey", r.relayerKey.GetKey().String()),
 			zap.Error(err),
 		)
 		return 0, err
@@ -684,7 +684,7 @@ func (r *messageRelayer) setProcessedBlockHeightToLatest() (uint64, error) {
 // because it is updated as soon as a single message from that block is relayed,
 // and there may be multiple message in the same block.
 func (r *messageRelayer) getLatestProcessedBlockHeight() (uint64, error) {
-	latestProcessedBlockData, err := r.db.Get(r.relayerKey.CalculateRelayerKey(), []byte(database.LatestProcessedBlockKey))
+	latestProcessedBlockData, err := r.db.Get(r.relayerKey.GetKey(), []byte(database.LatestProcessedBlockKey))
 	if err != nil {
 		return 0, err
 	}
@@ -697,7 +697,7 @@ func (r *messageRelayer) getLatestProcessedBlockHeight() (uint64, error) {
 
 // Store the block height in the database. Does not check against the current latest processed block height.
 func (r *messageRelayer) storeBlockHeight(height uint64) error {
-	return r.db.Put(r.relayerKey.CalculateRelayerKey(), []byte(database.LatestProcessedBlockKey), []byte(strconv.FormatUint(height, 10)))
+	return r.db.Put(r.relayerKey.GetKey(), []byte(database.LatestProcessedBlockKey), []byte(strconv.FormatUint(height, 10)))
 }
 
 // Stores the block height in the database if it is greater than the current latest processed block height.
@@ -708,7 +708,7 @@ func (r *messageRelayer) storeLatestBlockHeight(height uint64) error {
 	if err != nil && !database.IsKeyNotFoundError(err) {
 		r.logger.Error(
 			"Encountered an unknown error while getting latest processed block from database",
-			zap.String("relayerKey", r.relayerKey.CalculateRelayerKey().String()),
+			zap.String("relayerKey", r.relayerKey.GetKey().String()),
 			zap.Error(err),
 		)
 		return err
@@ -722,7 +722,7 @@ func (r *messageRelayer) storeLatestBlockHeight(height uint64) error {
 		if err != nil {
 			r.logger.Error(
 				fmt.Sprintf("failed to put %s into database", database.LatestProcessedBlockKey),
-				zap.String("relayerKey", r.relayerKey.CalculateRelayerKey().String()),
+				zap.String("relayerKey", r.relayerKey.GetKey().String()),
 				zap.Error(err),
 			)
 		}

--- a/relayer/message_relayer_test.go
+++ b/relayer/message_relayer_test.go
@@ -35,7 +35,7 @@ func TestCalculateStartingBlockHeight(t *testing.T) {
 			name:          "value in cfg, no value in db",
 			cfgBlock:      100,
 			dbBlock:       0,
-			dbError:       database.ErrDataKeyNotFound,
+			dbError:       database.ErrKeyNotFound,
 			expectedBlock: 100,
 			expectedError: nil,
 		},

--- a/relayer/message_relayer_test.go
+++ b/relayer/message_relayer_test.go
@@ -72,7 +72,7 @@ func TestCalculateStartingBlockHeight(t *testing.T) {
 		relayerUnderTest, db := makeMessageRelayerWithMockDatabase(t)
 		db.
 			EXPECT().
-			Get(gomock.Any(), []byte(database.LatestProcessedBlockKey)).
+			Get(gomock.Any(), database.LatestProcessedBlockKey).
 			Return([]byte(strconv.FormatUint(testCase.dbBlock, 10)), testCase.dbError).
 			Times(1)
 		ret, err := relayerUnderTest.calculateStartingBlockHeight(testCase.cfgBlock)

--- a/relayer/message_relayer_test.go
+++ b/relayer/message_relayer_test.go
@@ -35,7 +35,7 @@ func TestCalculateStartingBlockHeight(t *testing.T) {
 			name:          "value in cfg, no value in db",
 			cfgBlock:      100,
 			dbBlock:       0,
-			dbError:       database.ErrKeyNotFound,
+			dbError:       database.ErrDataKeyNotFound,
 			expectedBlock: 100,
 			expectedError: nil,
 		},

--- a/relayer/message_relayer_test.go
+++ b/relayer/message_relayer_test.go
@@ -1,0 +1,86 @@
+package relayer
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/awm-relayer/database"
+	mock_database "github.com/ava-labs/awm-relayer/database/mocks"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func makeMessageRelayerWithMockDatabase(t *testing.T) (*messageRelayer, *mock_database.MockRelayerDatabase) {
+	db := mock_database.NewMockRelayerDatabase(gomock.NewController(t))
+
+	return &messageRelayer{
+		logger: logging.NoLog{},
+		db:     db,
+	}, db
+}
+
+func TestCalculateStartingBlockHeight(t *testing.T) {
+	testCases := []struct {
+		name          string
+		cfgBlock      uint64
+		dbBlock       uint64
+		dbError       error
+		expectedBlock uint64
+		expectedError error
+	}{
+		{
+			// Value in cfg, no value in db
+			name:          "value in cfg, no value in db",
+			cfgBlock:      100,
+			dbBlock:       0,
+			dbError:       database.ErrKeyNotFound,
+			expectedBlock: 100,
+			expectedError: nil,
+		},
+		{
+			// Unknown DB error
+			name:          "unknown DB error",
+			cfgBlock:      100,
+			dbBlock:       0,
+			dbError:       fmt.Errorf("unknown error"),
+			expectedBlock: 0,
+			expectedError: fmt.Errorf("unknown error"),
+		},
+		{
+			// DB value greater than cfg value
+			name:          "DB value greater than cfg value",
+			cfgBlock:      100,
+			dbBlock:       200,
+			dbError:       nil,
+			expectedBlock: 200,
+			expectedError: nil,
+		},
+		{
+			// cfg value greater than DB value
+			name:          "cfg value greater than DB value",
+			cfgBlock:      200,
+			dbBlock:       100,
+			dbError:       nil,
+			expectedBlock: 200,
+			expectedError: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		relayerUnderTest, db := makeMessageRelayerWithMockDatabase(t)
+		db.
+			EXPECT().
+			Get(gomock.Any(), []byte(database.LatestProcessedBlockKey)).
+			Return([]byte(strconv.FormatUint(testCase.dbBlock, 10)), testCase.dbError).
+			Times(1)
+		ret, err := relayerUnderTest.calculateStartingBlockHeight(testCase.cfgBlock)
+		if testCase.expectedError == nil {
+			require.NoError(t, err, fmt.Sprintf("test failed: %s", testCase.name))
+			require.Equal(t, testCase.expectedBlock, ret, fmt.Sprintf("test failed: %s", testCase.name))
+		} else {
+			require.Error(t, err, fmt.Sprintf("test failed: %s", testCase.name))
+		}
+	}
+}

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -88,14 +88,14 @@ func NewRelayer(
 
 	// Create the message relayers
 	messageRelayers := make(map[common.Hash]*messageRelayer)
-	for _, relayerKey := range database.GetSourceBlockchainRelayerKeys(&sourceBlockchain) {
+	for _, relayerID := range database.GetSourceBlockchainRelayerIDs(&sourceBlockchain) {
 		messageRelayer, err := newMessageRelayer(
 			logger,
 			metrics,
 			network,
 			messageCreator,
 			responseChan,
-			relayerKey,
+			relayerID,
 			db,
 			sourceBlockchain,
 			cfg,
@@ -103,12 +103,12 @@ func NewRelayer(
 		if err != nil {
 			logger.Error(
 				"Failed to create message relayer",
-				zap.String("relayerKey", relayerKey.GetKey().String()),
+				zap.String("relayerID", relayerID.GetID().String()),
 				zap.Error(err),
 			)
 			return nil, err
 		}
-		messageRelayers[relayerKey.GetKey()] = messageRelayer
+		messageRelayers[relayerID.GetID()] = messageRelayer
 	}
 
 	logger.Info(
@@ -354,13 +354,13 @@ func (r *Relayer) RelayMessage(warpLogInfo *vmtypes.WarpLogInfo, storeProcessedH
 		return nil
 	}
 
-	messageRelayerKey := database.CalculateRelayerKey(
+	messageRelayerID := database.CalculateRelayerID(
 		r.sourceBlockchain.GetBlockchainID(),
 		destinationBlockchainID,
 		common.Address{}, // TODO: Populate with the proper sender/receiver address
 		common.Address{},
 	)
-	messageRelayer, ok := r.messageRelayers[messageRelayerKey]
+	messageRelayer, ok := r.messageRelayers[messageRelayerID]
 	if !ok {
 		// TODO: If we don't find the key using the actual addresses, check if all sender/destination addresses are allowed
 		r.logger.Error(

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -88,7 +88,7 @@ func NewRelayer(
 
 	// Create the message relayers
 	messageRelayers := make(map[common.Hash]*messageRelayer)
-	for _, relayerKey := range database.GetSourceConfigRelayerKeys(&sourceBlockchain) {
+	for _, relayerKey := range database.GetSourceBlockchainRelayerKeys(&sourceBlockchain) {
 		messageRelayer, err := newMessageRelayer(logger, metrics, network, messageCreator, responseChan, relayerKey, db, sourceBlockchain, cfg)
 		if err != nil {
 			logger.Error(

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ava-labs/awm-relayer/database"
 	"github.com/ava-labs/awm-relayer/messages"
 	"github.com/ava-labs/awm-relayer/peers"
-	"github.com/ava-labs/awm-relayer/utils"
 	vms "github.com/ava-labs/awm-relayer/vms"
 	"github.com/ava-labs/awm-relayer/vms/vmtypes"
 	"github.com/ethereum/go-ethereum/common"
@@ -378,7 +377,7 @@ func (r *Relayer) RelayMessage(warpLogInfo *vmtypes.WarpLogInfo, storeProcessedH
 		return nil
 	}
 
-	messageRelayerKey := utils.CalculateRelayerKey(
+	messageRelayerKey := database.CalculateRelayerKey(
 		r.sourceBlockchainID,
 		destinationBlockchainID,
 		common.Address{}, // TODO: Populate with the proper sender/receiver address

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -103,12 +103,12 @@ func NewRelayer(
 		if err != nil {
 			logger.Error(
 				"Failed to create message relayer",
-				zap.String("relayerKey", relayerKey.CalculateRelayerKey().String()),
+				zap.String("relayerKey", relayerKey.GetKey().String()),
 				zap.Error(err),
 			)
 			return nil, err
 		}
-		messageRelayers[relayerKey.CalculateRelayerKey()] = messageRelayer
+		messageRelayers[relayerKey.GetKey()] = messageRelayer
 	}
 
 	logger.Info(

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -88,7 +88,7 @@ func NewRelayer(
 
 	// Create the message relayers
 	messageRelayers := make(map[common.Hash]*messageRelayer)
-	for _, relayerKey := range sourceBlockchain.GetRelayerKeys() {
+	for _, relayerKey := range database.GetSourceConfigRelayerKeys(&sourceBlockchain) {
 		messageRelayer, err := newMessageRelayer(logger, metrics, network, messageCreator, responseChan, relayerKey, db, sourceBlockchain, cfg)
 		if err != nil {
 			logger.Error(

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -366,7 +366,7 @@ func (r *Relayer) RelayMessage(warpLogInfo *vmtypes.WarpLogInfo, storeProcessedH
 	// Relay the message to the destination. Messages from a given source chain must be processed in serial in order to
 	// guarantee that the previous block (n-1) is fully processed by the relayer when processing a given log from block n.
 	// TODO: Add a config option to use the Warp API, instead of hardcoding to the app request network here
-	err = messageRelayer.relayMessage(unsignedMessage, r.currentRequestID, messageManager, true)
+	err = messageRelayer.relayMessage(unsignedMessage, r.currentRequestID, messageManager, storeProcessedHeight, warpLogInfo.BlockNumber, true)
 	if err != nil {
 		r.logger.Error(
 			"Failed to run message relayer",
@@ -379,13 +379,7 @@ func (r *Relayer) RelayMessage(warpLogInfo *vmtypes.WarpLogInfo, storeProcessedH
 
 	// Increment the request ID for the next message relay request
 	r.currentRequestID++
-
-	if !storeProcessedHeight {
-		return nil
-	}
-
-	// Update the database with the latest processed block height
-	return messageRelayer.storeLatestBlockHeight(warpLogInfo.BlockNumber)
+	return nil
 }
 
 // Returns whether destinationBlockchainID is a supported destination.

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -89,7 +89,17 @@ func NewRelayer(
 	// Create the message relayers
 	messageRelayers := make(map[common.Hash]*messageRelayer)
 	for _, relayerKey := range database.GetSourceBlockchainRelayerKeys(&sourceBlockchain) {
-		messageRelayer, err := newMessageRelayer(logger, metrics, network, messageCreator, responseChan, relayerKey, db, sourceBlockchain, cfg)
+		messageRelayer, err := newMessageRelayer(
+			logger,
+			metrics,
+			network,
+			messageCreator,
+			responseChan,
+			relayerKey,
+			db,
+			sourceBlockchain,
+			cfg,
+		)
 		if err != nil {
 			logger.Error(
 				"Failed to create message relayer",

--- a/relayer/relayer_test.go
+++ b/relayer/relayer_test.go
@@ -38,12 +38,12 @@ func makeRelayerWithMockDatabase(t *testing.T) (*Relayer, *mock_database.MockRel
 
 	return &Relayer{
 		sourceBlockchainID: blockchainID,
-		db:                 mockDatabase,
 		logger:             logger,
 	}, mockDatabase
 }
 
 func TestCheckSupportedDestination(t *testing.T) {
+	t.Skip()
 	testCases := []struct {
 		name                    string
 		relayer                 Relayer
@@ -79,6 +79,7 @@ func TestCheckSupportedDestination(t *testing.T) {
 }
 
 func TestCalculateStartingBlockHeight(t *testing.T) {
+	t.Skip()
 	testCases := []struct {
 		name          string
 		cfgBlock      uint64
@@ -132,7 +133,7 @@ func TestCalculateStartingBlockHeight(t *testing.T) {
 			Get(gomock.Any(), []byte(database.LatestProcessedBlockKey)).
 			Return([]byte(strconv.FormatUint(testCase.dbBlock, 10)), testCase.dbError).
 			Times(1)
-		ret, err := relayerUnderTest.calculateStartingBlockHeight(testCase.cfgBlock)
+		ret, err := relayerUnderTest.calculateListenerStartingBlockHeight(testCase.cfgBlock)
 		if testCase.expectedError == nil {
 			require.NoError(t, err, fmt.Sprintf("test failed: %s", testCase.name))
 			require.Equal(t, testCase.expectedBlock, ret, fmt.Sprintf("test failed: %s", testCase.name))

--- a/relayer/relayer_test.go
+++ b/relayer/relayer_test.go
@@ -47,7 +47,6 @@ func populateSourceConfig(blockchainIDs []ids.ID, supportedDestinations []string
 }
 
 func makeTestRelayer(t *testing.T, supportedDestinations []string) *Relayer {
-
 	logger := logging.NewLogger(
 		"awm-relayer-test",
 		logging.NewWrappedCore(

--- a/tests/basic_relay.go
+++ b/tests/basic_relay.go
@@ -121,7 +121,7 @@ func BasicRelay(network interfaces.LocalNetwork) {
 	jsonDB, err := database.NewJSONFileStorage(logger, relayerConfig.StorageLocation, database.GetConfigRelayerKeys(&relayerConfig))
 	Expect(err).Should(BeNil())
 
-	relayerKeyA := database.CalculateRelayerKey(subnetAInfo.BlockchainID, subnetBInfo.BlockchainID, common.Address{}, common.Address{})
+	relayerKeyA := database.CalculateRelayerKey(subnetAInfo.BlockchainID, subnetBInfo.BlockchainID, common.Address{}, common.Address{}) // TODO: update the src/dst addresses once allow lists added
 	relayerKeyB := database.CalculateRelayerKey(subnetBInfo.BlockchainID, subnetAInfo.BlockchainID, common.Address{}, common.Address{})
 	// Modify the JSON database to force the relayer to re-process old blocks
 	jsonDB.Put(relayerKeyA, []byte(database.LatestProcessedBlockKey), []byte("0"))

--- a/tests/basic_relay.go
+++ b/tests/basic_relay.go
@@ -111,8 +111,8 @@ func BasicRelay(network interfaces.LocalNetwork) {
 	relayerKeyA := database.CalculateRelayerKey(subnetAInfo.BlockchainID, subnetBInfo.BlockchainID, common.Address{}, common.Address{}) // TODO: update the src/dst addresses once allow lists added
 	relayerKeyB := database.CalculateRelayerKey(subnetBInfo.BlockchainID, subnetAInfo.BlockchainID, common.Address{}, common.Address{})
 	// Modify the JSON database to force the relayer to re-process old blocks
-	jsonDB.Put(relayerKeyA, []byte(database.LatestProcessedBlockKey), []byte("0"))
-	jsonDB.Put(relayerKeyB, []byte(database.LatestProcessedBlockKey), []byte("0"))
+	jsonDB.Put(relayerKeyA, database.LatestProcessedBlockKey, []byte("0"))
+	jsonDB.Put(relayerKeyB, database.LatestProcessedBlockKey, []byte("0"))
 
 	// Subscribe to the destination chain
 	newHeadsB := make(chan *types.Header, 10)

--- a/tests/basic_relay.go
+++ b/tests/basic_relay.go
@@ -2,29 +2,15 @@ package tests
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"encoding/json"
-	"math/big"
 	"os"
 	"time"
 
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
-	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
-	warpPayload "github.com/ava-labs/avalanchego/vms/platformvm/warp/payload"
-	"github.com/ava-labs/awm-relayer/config"
 	"github.com/ava-labs/awm-relayer/database"
 	testUtils "github.com/ava-labs/awm-relayer/tests/utils"
-	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
 	"github.com/ava-labs/subnet-evm/core/types"
-	"github.com/ava-labs/subnet-evm/precompile/contracts/warp"
-	predicateutils "github.com/ava-labs/subnet-evm/predicate"
-	subnetevmutils "github.com/ava-labs/subnet-evm/utils"
-	teleportermessenger "github.com/ava-labs/teleporter/abi-bindings/go/Teleporter/TeleporterMessenger"
 	"github.com/ava-labs/teleporter/tests/interfaces"
 	"github.com/ava-labs/teleporter/tests/utils"
-	teleporterTestUtils "github.com/ava-labs/teleporter/tests/utils"
-	teleporterUtils "github.com/ava-labs/teleporter/utils/teleporter-utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -59,12 +45,13 @@ func BasicRelay(network interfaces.LocalNetwork) {
 	//
 	relayerConfig := testUtils.CreateDefaultRelayerConfig(
 		[]interfaces.SubnetTestInfo{subnetAInfo, subnetBInfo},
+		[]interfaces.SubnetTestInfo{subnetAInfo, subnetBInfo},
 		teleporterContractAddress,
 		fundedAddress,
 		relayerKey,
 	)
 
-	relayerConfigPath := writeRelayerConfig(relayerConfig)
+	relayerConfigPath := testUtils.WriteRelayerConfig(relayerConfig, testUtils.DefaultRelayerCfgFname)
 
 	//
 	// Test Relaying from Subnet A to Subnet B
@@ -80,7 +67,7 @@ func BasicRelay(network interfaces.LocalNetwork) {
 	time.Sleep(15 * time.Second)
 
 	log.Info("Sending transaction from Subnet A to Subnet B")
-	relayBasicMessage(
+	testUtils.RelayBasicMessage(
 		ctx,
 		subnetAInfo,
 		subnetBInfo,
@@ -93,7 +80,7 @@ func BasicRelay(network interfaces.LocalNetwork) {
 	// Test Relaying from Subnet B to Subnet A
 	//
 	log.Info("Test Relaying from Subnet B to Subnet A")
-	relayBasicMessage(
+	testUtils.RelayBasicMessage(
 		ctx,
 		subnetBInfo,
 		subnetAInfo,
@@ -142,193 +129,17 @@ func BasicRelay(network interfaces.LocalNetwork) {
 	log.Info("Waiting for 10s to ensure no new block confirmations on destination chain")
 	Consistently(newHeadsB, 10*time.Second, 500*time.Millisecond).ShouldNot(Receive())
 
-	// Cancel the command and stop the relayer
-	relayerCleanup()
-
 	//
 	// Set ProcessHistoricalBlocksFromHeight in config
 	//
 	log.Info("Test Setting ProcessHistoricalBlocksFromHeight in config")
-
-	// Send three Teleporter messages from subnet A to subnet B
-	log.Info("Sending three Teleporter messages from subnet A to subnet B")
-	_, _, id1 := sendBasicTeleporterMessage(ctx, subnetAInfo, subnetBInfo, fundedKey, fundedAddress)
-	_, _, id2 := sendBasicTeleporterMessage(ctx, subnetAInfo, subnetBInfo, fundedKey, fundedAddress)
-	_, _, id3 := sendBasicTeleporterMessage(ctx, subnetAInfo, subnetBInfo, fundedKey, fundedAddress)
-
-	currHeight, err := subnetAInfo.RPCClient.BlockNumber(ctx)
-	Expect(err).Should(BeNil())
-	log.Info("Current block height", "height", currHeight)
-
-	// Configure the relayer such that it will only process the last of the three messages sent above.
-	// The relayer DB stores the height of the block *before* the first message, so by setting the
-	// ProcessHistoricalBlocksFromHeight to the block height of the *third* message, we expect the relayer to skip
-	// the first two messages on startup, but process the third.
-	modifiedRelayerConfig := relayerConfig
-	modifiedRelayerConfig.SourceBlockchains[0].ProcessHistoricalBlocksFromHeight = currHeight
-	modifiedRelayerConfig.ProcessMissedBlocks = true
-	relayerConfigPath = writeRelayerConfig(modifiedRelayerConfig)
-
-	log.Info("Starting the relayer")
-	relayerCleanup = testUtils.BuildAndRunRelayerExecutable(ctx, relayerConfigPath)
-	defer relayerCleanup()
-	log.Info("Waiting for a new block confirmation on subnet B")
-	<-newHeadsB
-	delivered1, err := subnetBInfo.TeleporterMessenger.MessageReceived(
-		&bind.CallOpts{}, id1,
-	)
-	Expect(err).Should(BeNil())
-	delivered2, err := subnetBInfo.TeleporterMessenger.MessageReceived(
-		&bind.CallOpts{}, id2,
-	)
-	Expect(err).Should(BeNil())
-	delivered3, err := subnetBInfo.TeleporterMessenger.MessageReceived(
-		&bind.CallOpts{}, id3,
-	)
-	Expect(err).Should(BeNil())
-	Expect(delivered1).Should(BeFalse())
-	Expect(delivered2).Should(BeFalse())
-	Expect(delivered3).Should(BeTrue())
-}
-
-func sendBasicTeleporterMessage(
-	ctx context.Context,
-	source interfaces.SubnetTestInfo,
-	destination interfaces.SubnetTestInfo,
-	fundedKey *ecdsa.PrivateKey,
-	fundedAddress common.Address,
-) (*types.Receipt, teleportermessenger.TeleporterMessage, ids.ID) {
-	input := teleportermessenger.TeleporterMessageInput{
-		DestinationBlockchainID: destination.BlockchainID,
-		DestinationAddress:      fundedAddress,
-		FeeInfo: teleportermessenger.TeleporterFeeInfo{
-			FeeTokenAddress: fundedAddress,
-			Amount:          big.NewInt(0),
-		},
-		RequiredGasLimit:        big.NewInt(1),
-		AllowedRelayerAddresses: []common.Address{},
-		Message:                 []byte{1, 2, 3, 4},
-	}
-
-	// Send a transaction to the Teleporter contract
-	log.Info(
-		"Sending teleporter transaction",
-		"sourceBlockchainID", source.BlockchainID,
-		"destinationBlockchainID", destination.BlockchainID,
-	)
-	receipt, teleporterMessageID := teleporterTestUtils.SendCrossChainMessageAndWaitForAcceptance(
+	testUtils.TriggerProcessMissedBlocks(
 		ctx,
-		source,
-		destination,
-		input,
-		fundedKey,
-	)
-	sendEvent, err := teleporterTestUtils.GetEventFromLogs(receipt.Logs, source.TeleporterMessenger.ParseSendCrossChainMessage)
-	Expect(err).Should(BeNil())
-
-	return receipt, sendEvent.Message, teleporterMessageID
-}
-
-func relayBasicMessage(
-	ctx context.Context,
-	source interfaces.SubnetTestInfo,
-	destination interfaces.SubnetTestInfo,
-	teleporterContractAddress common.Address,
-	fundedKey *ecdsa.PrivateKey,
-	fundedAddress common.Address,
-) {
-	newHeadsDest := make(chan *types.Header, 10)
-	sub, err := destination.WSClient.SubscribeNewHead(ctx, newHeadsDest)
-	Expect(err).Should(BeNil())
-	defer sub.Unsubscribe()
-
-	_, teleporterMessage, teleporterMessageID := sendBasicTeleporterMessage(
-		ctx,
-		source,
-		destination,
-		fundedKey,
+		subnetAInfo,
+		subnetBInfo,
+		relayerCleanup,
+		relayerConfig,
 		fundedAddress,
+		fundedKey,
 	)
-
-	log.Info("Waiting for new block confirmation")
-	newHead := <-newHeadsDest
-	blockNumber := newHead.Number
-	log.Info(
-		"Received new head",
-		"height", blockNumber.Uint64(),
-		"hash", newHead.Hash(),
-	)
-	block, err := destination.RPCClient.BlockByNumber(ctx, blockNumber)
-	Expect(err).Should(BeNil())
-	log.Info(
-		"Got block",
-		"blockHash", block.Hash(),
-		"blockNumber", block.NumberU64(),
-		"transactions", block.Transactions(),
-		"numTransactions", len(block.Transactions()),
-		"block", block,
-	)
-	accessLists := block.Transactions()[0].AccessList()
-	Expect(len(accessLists)).Should(Equal(1))
-	Expect(accessLists[0].Address).Should(Equal(warp.Module.Address))
-
-	// Check the transaction storage key has warp message we're expecting
-	storageKeyHashes := accessLists[0].StorageKeys
-	packedPredicate := subnetevmutils.HashSliceToBytes(storageKeyHashes)
-	predicateBytes, err := predicateutils.UnpackPredicate(packedPredicate)
-	Expect(err).Should(BeNil())
-	receivedWarpMessage, err := avalancheWarp.ParseMessage(predicateBytes)
-	Expect(err).Should(BeNil())
-
-	// Check that the transaction has successful receipt status
-	txHash := block.Transactions()[0].Hash()
-	receipt, err := destination.RPCClient.TransactionReceipt(ctx, txHash)
-	Expect(err).Should(BeNil())
-	Expect(receipt.Status).Should(Equal(types.ReceiptStatusSuccessful))
-
-	// Check that the transaction emits ReceiveCrossChainMessage
-	receiveEvent, err := teleporterTestUtils.GetEventFromLogs(receipt.Logs, destination.TeleporterMessenger.ParseReceiveCrossChainMessage)
-	Expect(err).Should(BeNil())
-	Expect(receiveEvent.SourceBlockchainID[:]).Should(Equal(source.BlockchainID[:]))
-	Expect(receiveEvent.MessageID[:]).Should(Equal(teleporterMessageID[:]))
-
-	//
-	// Validate Received Warp Message Values
-	//
-	log.Info("Validating received warp message")
-	Expect(receivedWarpMessage.SourceChainID).Should(Equal(source.BlockchainID))
-	addressedPayload, err := warpPayload.ParseAddressedCall(receivedWarpMessage.Payload)
-	Expect(err).Should(BeNil())
-
-	// Check that the teleporter message is correct
-	// We don't validate the entire message, since the message receipts
-	// are populated by the Teleporter contract
-	receivedTeleporterMessage, err := teleportermessenger.UnpackTeleporterMessage(addressedPayload.Payload)
-	Expect(err).Should(BeNil())
-
-	receivedMessageID, err := teleporterUtils.CalculateMessageID(teleporterContractAddress, source.BlockchainID, destination.BlockchainID, teleporterMessage.MessageNonce)
-	Expect(err).Should(BeNil())
-	Expect(receivedMessageID).Should(Equal(teleporterMessageID))
-	Expect(receivedTeleporterMessage.OriginSenderAddress).Should(Equal(teleporterMessage.OriginSenderAddress))
-	receivedDestinationID, err := ids.ToID(receivedTeleporterMessage.DestinationBlockchainID[:])
-	Expect(err).Should(BeNil())
-	Expect(receivedDestinationID).Should(Equal(destination.BlockchainID))
-	Expect(receivedTeleporterMessage.DestinationAddress).Should(Equal(teleporterMessage.DestinationAddress))
-	Expect(receivedTeleporterMessage.RequiredGasLimit.Uint64()).Should(Equal(teleporterMessage.RequiredGasLimit.Uint64()))
-	Expect(receivedTeleporterMessage.Message).Should(Equal(teleporterMessage.Message))
-}
-
-func writeRelayerConfig(relayerConfig config.Config) string {
-	data, err := json.MarshalIndent(relayerConfig, "", "\t")
-	Expect(err).Should(BeNil())
-
-	f, err := os.CreateTemp(os.TempDir(), "relayer-config.json")
-	Expect(err).Should(BeNil())
-
-	_, err = f.Write(data)
-	Expect(err).Should(BeNil())
-	relayerConfigPath := f.Name()
-
-	log.Info("Created awm-relayer config", "configPath", relayerConfigPath, "config", string(data))
-	return relayerConfigPath
 }

--- a/tests/basic_relay.go
+++ b/tests/basic_relay.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ava-labs/awm-relayer/config"
 	"github.com/ava-labs/awm-relayer/database"
 	testUtils "github.com/ava-labs/awm-relayer/tests/utils"
-	relayerUtils "github.com/ava-labs/awm-relayer/utils"
 	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/warp"
@@ -119,11 +118,11 @@ func BasicRelay(network interfaces.LocalNetwork) {
 			logging.JSON.ConsoleEncoder(),
 		),
 	)
-	jsonDB, err := database.NewJSONFileStorage(logger, relayerConfig)
+	jsonDB, err := database.NewJSONFileStorage(logger, relayerConfig.StorageLocation, relayerConfig.GetAllRelayerKeys())
 	Expect(err).Should(BeNil())
 
-	relayerKeyA := relayerUtils.CalculateRelayerKey(subnetAInfo.BlockchainID, subnetBInfo.BlockchainID, common.Address{}, common.Address{})
-	relayerKeyB := relayerUtils.CalculateRelayerKey(subnetBInfo.BlockchainID, subnetAInfo.BlockchainID, common.Address{}, common.Address{})
+	relayerKeyA := database.CalculateRelayerKey(subnetAInfo.BlockchainID, subnetBInfo.BlockchainID, common.Address{}, common.Address{})
+	relayerKeyB := database.CalculateRelayerKey(subnetBInfo.BlockchainID, subnetAInfo.BlockchainID, common.Address{}, common.Address{})
 	// Modify the JSON database to force the relayer to re-process old blocks
 	jsonDB.Put(relayerKeyA, []byte(database.LatestProcessedBlockKey), []byte("0"))
 	jsonDB.Put(relayerKeyB, []byte(database.LatestProcessedBlockKey), []byte("0"))

--- a/tests/basic_relay.go
+++ b/tests/basic_relay.go
@@ -118,7 +118,7 @@ func BasicRelay(network interfaces.LocalNetwork) {
 			logging.JSON.ConsoleEncoder(),
 		),
 	)
-	jsonDB, err := database.NewJSONFileStorage(logger, relayerConfig.StorageLocation, relayerConfig.GetAllRelayerKeys())
+	jsonDB, err := database.NewJSONFileStorage(logger, relayerConfig.StorageLocation, database.GetConfigRelayerKeys(&relayerConfig))
 	Expect(err).Should(BeNil())
 
 	relayerKeyA := database.CalculateRelayerKey(subnetAInfo.BlockchainID, subnetBInfo.BlockchainID, common.Address{}, common.Address{})

--- a/tests/basic_relay.go
+++ b/tests/basic_relay.go
@@ -105,14 +105,14 @@ func BasicRelay(network interfaces.LocalNetwork) {
 			logging.JSON.ConsoleEncoder(),
 		),
 	)
-	jsonDB, err := database.NewJSONFileStorage(logger, relayerConfig.StorageLocation, database.GetConfigRelayerKeys(&relayerConfig))
+	jsonDB, err := database.NewJSONFileStorage(logger, relayerConfig.StorageLocation, database.GetConfigRelayerIDs(&relayerConfig))
 	Expect(err).Should(BeNil())
 
-	relayerKeyA := database.CalculateRelayerKey(subnetAInfo.BlockchainID, subnetBInfo.BlockchainID, common.Address{}, common.Address{}) // TODO: update the src/dst addresses once allow lists added
-	relayerKeyB := database.CalculateRelayerKey(subnetBInfo.BlockchainID, subnetAInfo.BlockchainID, common.Address{}, common.Address{})
+	relayerIDA := database.CalculateRelayerID(subnetAInfo.BlockchainID, subnetBInfo.BlockchainID, common.Address{}, common.Address{}) // TODO: update the src/dst addresses once allow lists added
+	relayerIDB := database.CalculateRelayerID(subnetBInfo.BlockchainID, subnetAInfo.BlockchainID, common.Address{}, common.Address{})
 	// Modify the JSON database to force the relayer to re-process old blocks
-	jsonDB.Put(relayerKeyA, database.LatestProcessedBlockKey, []byte("0"))
-	jsonDB.Put(relayerKeyB, database.LatestProcessedBlockKey, []byte("0"))
+	jsonDB.Put(relayerIDA, database.LatestProcessedBlockKey, []byte("0"))
+	jsonDB.Put(relayerIDB, database.LatestProcessedBlockKey, []byte("0"))
 
 	// Subscribe to the destination chain
 	newHeadsB := make(chan *types.Header, 10)

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -71,4 +71,7 @@ var _ = ginkgo.Describe("[AWM Relayer Integration Tests", func() {
 	ginkgo.It("Teleporter Registry", func() {
 		TeleporterRegistry(localNetworkInstance)
 	})
+	ginkgo.It("Shared Database", func() {
+		SharedDatabaseAccess(localNetworkInstance)
+	})
 })

--- a/tests/manual_message.go
+++ b/tests/manual_message.go
@@ -46,16 +46,17 @@ func ManualMessage(network interfaces.LocalNetwork) {
 
 	log.Info("Sending two teleporter messages on subnet A")
 	// This message will be delivered by the relayer
-	receipt1, _, id1 := sendBasicTeleporterMessage(ctx, subnetAInfo, subnetBInfo, fundedKey, fundedAddress)
+	receipt1, _, id1 := testUtils.SendBasicTeleporterMessage(ctx, subnetAInfo, subnetBInfo, fundedKey, fundedAddress)
 	msg1 := getWarpMessageFromLog(ctx, receipt1, subnetAInfo)
 
 	// This message will not be delivered by the relayer
-	_, _, id2 := sendBasicTeleporterMessage(ctx, subnetAInfo, subnetBInfo, fundedKey, fundedAddress)
+	_, _, id2 := testUtils.SendBasicTeleporterMessage(ctx, subnetAInfo, subnetBInfo, fundedKey, fundedAddress)
 
 	//
 	// Set up relayer config to deliver one of the two previously sent messages
 	//
 	relayerConfig := testUtils.CreateDefaultRelayerConfig(
+		[]interfaces.SubnetTestInfo{subnetAInfo, subnetBInfo},
 		[]interfaces.SubnetTestInfo{subnetAInfo, subnetBInfo},
 		teleporterContractAddress,
 		fundedAddress,
@@ -71,7 +72,7 @@ func ManualMessage(network interfaces.LocalNetwork) {
 		},
 	}
 
-	relayerConfigPath := writeRelayerConfig(relayerConfig)
+	relayerConfigPath := testUtils.WriteRelayerConfig(relayerConfig, testUtils.DefaultRelayerCfgFname)
 
 	//
 	// Run the Relayer. On startup, we should deliver the message provided in the config

--- a/tests/shared_db.go
+++ b/tests/shared_db.go
@@ -16,7 +16,6 @@ const relayerCfgFname1 = "relayer-config-1.json"
 const relayerCfgFname2 = "relayer-config-2.json"
 
 func SharedDatabaseAccess(network interfaces.LocalNetwork) {
-
 	subnetAInfo := network.GetPrimaryNetworkInfo()
 	subnetBInfo, _ := utils.GetTwoSubnets(network)
 	fundedAddress, fundedKey := network.GetFundedAccountInfo()

--- a/tests/shared_db.go
+++ b/tests/shared_db.go
@@ -1,0 +1,128 @@
+package tests
+
+import (
+	"context"
+	"time"
+
+	testUtils "github.com/ava-labs/awm-relayer/tests/utils"
+	"github.com/ava-labs/teleporter/tests/interfaces"
+	"github.com/ava-labs/teleporter/tests/utils"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	. "github.com/onsi/gomega"
+)
+
+const relayerCfgFname1 = "relayer-config-1.json"
+const relayerCfgFname2 = "relayer-config-2.json"
+
+func SharedDatabaseAccess(network interfaces.LocalNetwork) {
+
+	subnetAInfo := network.GetPrimaryNetworkInfo()
+	subnetBInfo, _ := utils.GetTwoSubnets(network)
+	fundedAddress, fundedKey := network.GetFundedAccountInfo()
+	teleporterContractAddress := network.GetTeleporterContractAddress()
+	err := testUtils.ClearRelayerStorage()
+	Expect(err).Should(BeNil())
+
+	//
+	// Fund the relayer address on all subnets
+	//
+	ctx := context.Background()
+
+	log.Info("Funding relayer address on all subnets")
+	relayerKey1, err := crypto.GenerateKey()
+	Expect(err).Should(BeNil())
+	relayerKey2, err := crypto.GenerateKey()
+	Expect(err).Should(BeNil())
+
+	testUtils.FundRelayers(ctx, []interfaces.SubnetTestInfo{subnetAInfo, subnetBInfo}, fundedKey, relayerKey1)
+	testUtils.FundRelayers(ctx, []interfaces.SubnetTestInfo{subnetAInfo, subnetBInfo}, fundedKey, relayerKey2)
+
+	//
+	// Set up relayer config
+	//
+	// Relayer 1 will relay messages from Subnet A to Subnet B
+	relayerConfig1 := testUtils.CreateDefaultRelayerConfig(
+		[]interfaces.SubnetTestInfo{subnetAInfo},
+		[]interfaces.SubnetTestInfo{subnetBInfo},
+		teleporterContractAddress,
+		fundedAddress,
+		relayerKey1,
+	)
+	// Relayer 2 will relay messages from Subnet B to Subnet A
+	relayerConfig2 := testUtils.CreateDefaultRelayerConfig(
+		[]interfaces.SubnetTestInfo{subnetBInfo},
+		[]interfaces.SubnetTestInfo{subnetAInfo},
+		teleporterContractAddress,
+		fundedAddress,
+		relayerKey2,
+	)
+	relayerConfig2.APIPort = 8081
+	relayerConfig2.MetricsPort = 9091
+
+	relayerConfigPath1 := testUtils.WriteRelayerConfig(relayerConfig1, relayerCfgFname1)
+	relayerConfigPath2 := testUtils.WriteRelayerConfig(relayerConfig2, relayerCfgFname2)
+
+	//
+	// Test Relaying from Subnet A to Subnet B
+	//
+	log.Info("Test Relaying from Subnet A to Subnet B")
+
+	log.Info("Starting the relayers")
+	relayerCleanup1 := testUtils.BuildAndRunRelayerExecutable(ctx, relayerConfigPath1)
+	defer relayerCleanup1()
+	relayerCleanup2 := testUtils.BuildAndRunRelayerExecutable(ctx, relayerConfigPath2)
+	defer relayerCleanup2()
+
+	// Sleep for some time to make sure relayer has started up and subscribed.
+	log.Info("Waiting for the relayers to start up")
+	time.Sleep(15 * time.Second)
+
+	log.Info("Sending transaction from Subnet A to Subnet B")
+	testUtils.RelayBasicMessage(
+		ctx,
+		subnetAInfo,
+		subnetBInfo,
+		teleporterContractAddress,
+		fundedKey,
+		fundedAddress,
+	)
+
+	//
+	// Test Relaying from Subnet B to Subnet A
+	//
+	log.Info("Test Relaying from Subnet B to Subnet A")
+	testUtils.RelayBasicMessage(
+		ctx,
+		subnetBInfo,
+		subnetAInfo,
+		teleporterContractAddress,
+		fundedKey,
+		fundedAddress,
+	)
+
+	log.Info("Finished sending warp messages.")
+
+	// Test processing missed blocks on both relayers.
+	log.Info("Testing processing missed blocks on Subnet A")
+	testUtils.TriggerProcessMissedBlocks(
+		ctx,
+		subnetAInfo,
+		subnetBInfo,
+		relayerCleanup1,
+		relayerConfig1,
+		fundedAddress,
+		fundedKey,
+	)
+
+	log.Info("Testing processing missed blocks on Subnet B")
+	testUtils.TriggerProcessMissedBlocks(
+		ctx,
+		subnetBInfo,
+		subnetAInfo,
+		relayerCleanup2,
+		relayerConfig2,
+		fundedAddress,
+		fundedKey,
+	)
+}

--- a/tests/teleporter_registry.go
+++ b/tests/teleporter_registry.go
@@ -81,6 +81,7 @@ func TeleporterRegistry(network interfaces.LocalNetwork) {
 	//
 	relayerConfig := testUtils.CreateDefaultRelayerConfig(
 		[]interfaces.SubnetTestInfo{cChainInfo},
+		[]interfaces.SubnetTestInfo{cChainInfo},
 		teleporterContractAddress,
 		fundedAddress,
 		relayerKey,
@@ -94,7 +95,7 @@ func TeleporterRegistry(network interfaces.LocalNetwork) {
 			DestinationAddress:      cChainInfo.TeleporterRegistryAddress.Hex(),
 		},
 	}
-	relayerConfigPath := writeRelayerConfig(relayerConfig)
+	relayerConfigPath := testUtils.WriteRelayerConfig(relayerConfig, testUtils.DefaultRelayerCfgFname)
 	//
 	// Run the Relayer. On startup, we should deliver the message provided in the config
 	//

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -8,18 +8,29 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"os"
 	"os/exec"
 	"strings"
 
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	warpPayload "github.com/ava-labs/avalanchego/vms/platformvm/warp/payload"
 	"github.com/ava-labs/awm-relayer/config"
 	offchainregistry "github.com/ava-labs/awm-relayer/messages/off-chain-registry"
+	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
+	"github.com/ava-labs/subnet-evm/core/types"
+	"github.com/ava-labs/subnet-evm/precompile/contracts/warp"
+	predicateutils "github.com/ava-labs/subnet-evm/predicate"
+	subnetevmutils "github.com/ava-labs/subnet-evm/utils"
+	teleportermessenger "github.com/ava-labs/teleporter/abi-bindings/go/Teleporter/TeleporterMessenger"
 	"github.com/ava-labs/teleporter/tests/interfaces"
 	"github.com/ava-labs/teleporter/tests/utils"
 	teleporterTestUtils "github.com/ava-labs/teleporter/tests/utils"
+	teleporterUtils "github.com/ava-labs/teleporter/utils/teleporter-utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -27,7 +38,9 @@ import (
 )
 
 // Write the test database to /tmp since the data is not needed after the test
-var storageLocation = fmt.Sprintf("%s/.awm-relayer-storage", os.TempDir())
+var StorageLocation = fmt.Sprintf("%s/.awm-relayer-storage", os.TempDir())
+
+const DefaultRelayerCfgFname = "relayer-config.json"
 
 func BuildAndRunRelayerExecutable(ctx context.Context, relayerConfigPath string) context.CancelFunc {
 	// Build the awm-relayer binary
@@ -83,7 +96,8 @@ func ReadHexTextFile(filename string) string {
 
 // Constructs a relayer config with all subnets as sources and destinations
 func CreateDefaultRelayerConfig(
-	subnetsInfo []interfaces.SubnetTestInfo,
+	sourceSubnetsInfo []interfaces.SubnetTestInfo,
+	destinationSubnetsInfo []interfaces.SubnetTestInfo,
 	teleporterContractAddress common.Address,
 	fundedAddress common.Address,
 	relayerKey *ecdsa.PrivateKey,
@@ -92,9 +106,9 @@ func CreateDefaultRelayerConfig(
 		"Setting up relayer config",
 	)
 	// Construct the config values for each subnet
-	sources := make([]*config.SourceBlockchain, len(subnetsInfo))
-	destinations := make([]*config.DestinationBlockchain, len(subnetsInfo))
-	for i, subnetInfo := range subnetsInfo {
+	sources := make([]*config.SourceBlockchain, len(sourceSubnetsInfo))
+	destinations := make([]*config.DestinationBlockchain, len(destinationSubnetsInfo))
+	for i, subnetInfo := range sourceSubnetsInfo {
 		host, port, err := teleporterTestUtils.GetURIHostAndPort(subnetInfo.NodeURIs[0])
 		Expect(err).Should(BeNil())
 
@@ -121,6 +135,19 @@ func CreateDefaultRelayerConfig(
 			},
 		}
 
+		log.Info(
+			"Creating relayer config for source subnet",
+			"subnetID", subnetInfo.SubnetID.String(),
+			"blockchainID", subnetInfo.BlockchainID.String(),
+			"host", host,
+			"port", port,
+		)
+	}
+
+	for i, subnetInfo := range destinationSubnetsInfo {
+		host, port, err := teleporterTestUtils.GetURIHostAndPort(subnetInfo.NodeURIs[0])
+		Expect(err).Should(BeNil())
+
 		destinations[i] = &config.DestinationBlockchain{
 			SubnetID:          subnetInfo.SubnetID.String(),
 			BlockchainID:      subnetInfo.BlockchainID.String(),
@@ -130,7 +157,7 @@ func CreateDefaultRelayerConfig(
 		}
 
 		log.Info(
-			"Creating relayer config for subnet",
+			"Creating relayer config for destination subnet",
 			"subnetID", subnetInfo.SubnetID.String(),
 			"blockchainID", subnetInfo.BlockchainID.String(),
 			"host", host,
@@ -140,21 +167,17 @@ func CreateDefaultRelayerConfig(
 
 	return config.Config{
 		LogLevel:               logging.Info.LowerString(),
-		PChainAPIURL:           subnetsInfo[0].NodeURIs[0],
-		InfoAPIURL:             subnetsInfo[0].NodeURIs[0],
-		StorageLocation:        RelayerStorageLocation(),
+		PChainAPIURL:           sourceSubnetsInfo[0].NodeURIs[0],
+		InfoAPIURL:             sourceSubnetsInfo[0].NodeURIs[0],
+		StorageLocation:        StorageLocation,
 		ProcessMissedBlocks:    false,
 		SourceBlockchains:      sources,
 		DestinationBlockchains: destinations,
 	}
 }
 
-func RelayerStorageLocation() string {
-	return storageLocation
-}
-
 func ClearRelayerStorage() error {
-	return os.RemoveAll(storageLocation)
+	return os.RemoveAll(StorageLocation)
 }
 
 func FundRelayers(
@@ -172,4 +195,205 @@ func FundRelayers(
 		)
 		utils.SendTransactionAndWaitForSuccess(ctx, subnetInfo, fundRelayerTx)
 	}
+}
+
+func SendBasicTeleporterMessage(
+	ctx context.Context,
+	source interfaces.SubnetTestInfo,
+	destination interfaces.SubnetTestInfo,
+	fundedKey *ecdsa.PrivateKey,
+	fundedAddress common.Address,
+) (*types.Receipt, teleportermessenger.TeleporterMessage, ids.ID) {
+	input := teleportermessenger.TeleporterMessageInput{
+		DestinationBlockchainID: destination.BlockchainID,
+		DestinationAddress:      fundedAddress,
+		FeeInfo: teleportermessenger.TeleporterFeeInfo{
+			FeeTokenAddress: fundedAddress,
+			Amount:          big.NewInt(0),
+		},
+		RequiredGasLimit:        big.NewInt(1),
+		AllowedRelayerAddresses: []common.Address{},
+		Message:                 []byte{1, 2, 3, 4},
+	}
+
+	// Send a transaction to the Teleporter contract
+	log.Info(
+		"Sending teleporter transaction",
+		"sourceBlockchainID", source.BlockchainID,
+		"destinationBlockchainID", destination.BlockchainID,
+	)
+	receipt, teleporterMessageID := teleporterTestUtils.SendCrossChainMessageAndWaitForAcceptance(
+		ctx,
+		source,
+		destination,
+		input,
+		fundedKey,
+	)
+	sendEvent, err := teleporterTestUtils.GetEventFromLogs(receipt.Logs, source.TeleporterMessenger.ParseSendCrossChainMessage)
+	Expect(err).Should(BeNil())
+
+	return receipt, sendEvent.Message, teleporterMessageID
+}
+
+func RelayBasicMessage(
+	ctx context.Context,
+	source interfaces.SubnetTestInfo,
+	destination interfaces.SubnetTestInfo,
+	teleporterContractAddress common.Address,
+	fundedKey *ecdsa.PrivateKey,
+	fundedAddress common.Address,
+) {
+	newHeadsDest := make(chan *types.Header, 10)
+	sub, err := destination.WSClient.SubscribeNewHead(ctx, newHeadsDest)
+	Expect(err).Should(BeNil())
+	defer sub.Unsubscribe()
+
+	_, teleporterMessage, teleporterMessageID := SendBasicTeleporterMessage(
+		ctx,
+		source,
+		destination,
+		fundedKey,
+		fundedAddress,
+	)
+
+	log.Info("Waiting for new block confirmation")
+	newHead := <-newHeadsDest
+	blockNumber := newHead.Number
+	log.Info(
+		"Received new head",
+		"height", blockNumber.Uint64(),
+		"hash", newHead.Hash(),
+	)
+	block, err := destination.RPCClient.BlockByNumber(ctx, blockNumber)
+	Expect(err).Should(BeNil())
+	log.Info(
+		"Got block",
+		"blockHash", block.Hash(),
+		"blockNumber", block.NumberU64(),
+		"transactions", block.Transactions(),
+		"numTransactions", len(block.Transactions()),
+		"block", block,
+	)
+	accessLists := block.Transactions()[0].AccessList()
+	Expect(len(accessLists)).Should(Equal(1))
+	Expect(accessLists[0].Address).Should(Equal(warp.Module.Address))
+
+	// Check the transaction storage key has warp message we're expecting
+	storageKeyHashes := accessLists[0].StorageKeys
+	packedPredicate := subnetevmutils.HashSliceToBytes(storageKeyHashes)
+	predicateBytes, err := predicateutils.UnpackPredicate(packedPredicate)
+	Expect(err).Should(BeNil())
+	receivedWarpMessage, err := avalancheWarp.ParseMessage(predicateBytes)
+	Expect(err).Should(BeNil())
+
+	// Check that the transaction has successful receipt status
+	txHash := block.Transactions()[0].Hash()
+	receipt, err := destination.RPCClient.TransactionReceipt(ctx, txHash)
+	Expect(err).Should(BeNil())
+	Expect(receipt.Status).Should(Equal(types.ReceiptStatusSuccessful))
+
+	// Check that the transaction emits ReceiveCrossChainMessage
+	receiveEvent, err := teleporterTestUtils.GetEventFromLogs(receipt.Logs, destination.TeleporterMessenger.ParseReceiveCrossChainMessage)
+	Expect(err).Should(BeNil())
+	Expect(receiveEvent.SourceBlockchainID[:]).Should(Equal(source.BlockchainID[:]))
+	Expect(receiveEvent.MessageID[:]).Should(Equal(teleporterMessageID[:]))
+
+	//
+	// Validate Received Warp Message Values
+	//
+	log.Info("Validating received warp message")
+	Expect(receivedWarpMessage.SourceChainID).Should(Equal(source.BlockchainID))
+	addressedPayload, err := warpPayload.ParseAddressedCall(receivedWarpMessage.Payload)
+	Expect(err).Should(BeNil())
+
+	// Check that the teleporter message is correct
+	// We don't validate the entire message, since the message receipts
+	// are populated by the Teleporter contract
+	receivedTeleporterMessage, err := teleportermessenger.UnpackTeleporterMessage(addressedPayload.Payload)
+	Expect(err).Should(BeNil())
+
+	receivedMessageID, err := teleporterUtils.CalculateMessageID(teleporterContractAddress, source.BlockchainID, destination.BlockchainID, teleporterMessage.MessageNonce)
+	Expect(err).Should(BeNil())
+	Expect(receivedMessageID).Should(Equal(teleporterMessageID))
+	Expect(receivedTeleporterMessage.OriginSenderAddress).Should(Equal(teleporterMessage.OriginSenderAddress))
+	receivedDestinationID, err := ids.ToID(receivedTeleporterMessage.DestinationBlockchainID[:])
+	Expect(err).Should(BeNil())
+	Expect(receivedDestinationID).Should(Equal(destination.BlockchainID))
+	Expect(receivedTeleporterMessage.DestinationAddress).Should(Equal(teleporterMessage.DestinationAddress))
+	Expect(receivedTeleporterMessage.RequiredGasLimit.Uint64()).Should(Equal(teleporterMessage.RequiredGasLimit.Uint64()))
+	Expect(receivedTeleporterMessage.Message).Should(Equal(teleporterMessage.Message))
+}
+
+func WriteRelayerConfig(relayerConfig config.Config, fname string) string {
+	data, err := json.MarshalIndent(relayerConfig, "", "\t")
+	Expect(err).Should(BeNil())
+
+	f, err := os.CreateTemp(os.TempDir(), fname)
+	Expect(err).Should(BeNil())
+
+	_, err = f.Write(data)
+	Expect(err).Should(BeNil())
+	relayerConfigPath := f.Name()
+
+	log.Info("Created awm-relayer config", "configPath", relayerConfigPath, "config", string(data))
+	return relayerConfigPath
+}
+
+func TriggerProcessMissedBlocks(
+	ctx context.Context,
+	sourceSubnetInfo interfaces.SubnetTestInfo,
+	destinationSubnetInfo interfaces.SubnetTestInfo,
+	currRelayerCleanup context.CancelFunc,
+	currrentRelayerConfig config.Config,
+	fundedAddress common.Address,
+	fundedKey *ecdsa.PrivateKey,
+) {
+	// First, make sure the relayer is stopped
+	currRelayerCleanup()
+
+	// Subscribe to the destination chain
+	newHeads := make(chan *types.Header, 10)
+	sub, err := destinationSubnetInfo.WSClient.SubscribeNewHead(ctx, newHeads)
+	Expect(err).Should(BeNil())
+	defer sub.Unsubscribe()
+
+	// Send three Teleporter messages from subnet A to subnet B
+	log.Info("Sending three Teleporter messages from subnet A to subnet B")
+	_, _, id1 := SendBasicTeleporterMessage(ctx, sourceSubnetInfo, destinationSubnetInfo, fundedKey, fundedAddress)
+	_, _, id2 := SendBasicTeleporterMessage(ctx, sourceSubnetInfo, destinationSubnetInfo, fundedKey, fundedAddress)
+	_, _, id3 := SendBasicTeleporterMessage(ctx, sourceSubnetInfo, destinationSubnetInfo, fundedKey, fundedAddress)
+
+	currHeight, err := sourceSubnetInfo.RPCClient.BlockNumber(ctx)
+	Expect(err).Should(BeNil())
+	log.Info("Current block height", "height", currHeight)
+
+	// Configure the relayer such that it will only process the last of the three messages sent above.
+	// The relayer DB stores the height of the block *before* the first message, so by setting the
+	// ProcessHistoricalBlocksFromHeight to the block height of the *third* message, we expect the relayer to skip
+	// the first two messages on startup, but process the third.
+	modifiedRelayerConfig := currrentRelayerConfig
+	modifiedRelayerConfig.SourceBlockchains[0].ProcessHistoricalBlocksFromHeight = currHeight
+	modifiedRelayerConfig.ProcessMissedBlocks = true
+	relayerConfigPath := WriteRelayerConfig(modifiedRelayerConfig, DefaultRelayerCfgFname)
+
+	log.Info("Starting the relayer")
+	relayerCleanup := BuildAndRunRelayerExecutable(ctx, relayerConfigPath)
+	defer relayerCleanup()
+	log.Info("Waiting for a new block confirmation on subnet B")
+	<-newHeads
+	delivered1, err := destinationSubnetInfo.TeleporterMessenger.MessageReceived(
+		&bind.CallOpts{}, id1,
+	)
+	Expect(err).Should(BeNil())
+	delivered2, err := destinationSubnetInfo.TeleporterMessenger.MessageReceived(
+		&bind.CallOpts{}, id2,
+	)
+	Expect(err).Should(BeNil())
+	delivered3, err := destinationSubnetInfo.TeleporterMessenger.MessageReceived(
+		&bind.CallOpts{}, id3,
+	)
+	Expect(err).Should(BeNil())
+	Expect(delivered1).Should(BeFalse())
+	Expect(delivered2).Should(BeFalse())
+	Expect(delivered3).Should(BeTrue())
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -8,9 +8,7 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 )
 
 var (
@@ -74,23 +72,4 @@ func StripFromString(input, substring string) string {
 	strippedString := input[:index]
 
 	return strippedString
-}
-
-func CalculateRelayerKey(
-	sourceBlockchainID ids.ID,
-	destinationBlockchainID ids.ID,
-	originSenderAddress common.Address,
-	desinationAddress common.Address,
-) common.Hash {
-	return crypto.Keccak256Hash(
-		[]byte(strings.Join(
-			[]string{
-				sourceBlockchainID.String(),
-				destinationBlockchainID.String(),
-				originSenderAddress.String(),
-				desinationAddress.String(),
-			},
-			"-",
-		)),
-	)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -13,14 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-const (
-	// TODO: Revisit these constant values once we are using the subnet-evm branch with finalized
-	// Warp implementation. Should evaluate the maximum gas used by the Teleporter contract "receiveCrossChainMessage"
-	// method, excluding the call to execute the message payload.
-	ReceiveCrossChainMessageStaticGasCost           uint64 = 2_000_000
-	ReceiveCrossChainMessageGasCostPerAggregatedKey uint64 = 1_000
-)
-
 var (
 	// Errors
 	ErrNilInput = errors.New("nil input")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -8,7 +8,9 @@ import (
 	"math/big"
 	"strings"
 
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 const (
@@ -80,4 +82,23 @@ func StripFromString(input, substring string) string {
 	strippedString := input[:index]
 
 	return strippedString
+}
+
+func CalculateRelayerKey(
+	sourceBlockchainID ids.ID,
+	destinationBlockchainID ids.ID,
+	originSenderAddress common.Address,
+	desinationAddress common.Address,
+) common.Hash {
+	return crypto.Keccak256Hash(
+		[]byte(strings.Join(
+			[]string{
+				sourceBlockchainID.String(),
+				destinationBlockchainID.String(),
+				originSenderAddress.String(),
+				desinationAddress.String(),
+			},
+			"-",
+		)),
+	)
 }


### PR DESCRIPTION
## Why this should be merged
Fixes #240 

## How this works
- `messageRelayer` instances are persisted, and now pertain to a unique (source chain, destination chain, source address, destination address) tuple
- `Relayer` instances are composed of a set of `messageRelayers`, rather than `messageRelayer` being composed of the parent `Relayer`
- Migrates database interfacing methods from `Relayer` to `messageRelayer`
- Database keys changed from `ids.ID` to `common.Hash`
- Adds `DestinationAddress` and `SourceAddress` getters to `MessageManager` to facilitate key construction
- Adds database key utilities

## How this was tested
- CI, updated tests
- Added multiple relayers, single DB e2e test
- TODO: New unit tests

## How is this documented
Updated README