### PR TITLE
Snyk upload fix

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -27,6 +27,13 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif --all-projects --detection-depth=4
 
+      # Replace any "undefined" security severity values with 0. The undefined value is used in the case
+      # of license-related findings, which do not do not indicate a security vulnerability.
+      # See https://github.com/github/codeql-action/issues/2187 for more context.
+      - name: Post-process sarif output
+        run: |
+          sed -i 's/"security-severity": "undefined"/"security-severity": "0"/g' snyk.sarif
+
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -3,7 +3,7 @@
 # See the file LICENSE for licensing terms.
 
 # The go version for this project is set from a combination of major.minor from go.mod and the patch version set here.
-GO_PATCH_VERSION=8
+GO_PATCH_VERSION=9
 
 RELAYER_PATH=$(
   cd "$(dirname "${BASH_SOURCE[0]}")"


### PR DESCRIPTION
## Why this should be merged

Fixes the snyk workflow, and bumps the golang patch version to the latest 1.21 release.

## How this works

See https://github.com/github/codeql-action/issues/2187#issuecomment-2043220400

## How this was tested
CI

## How is this documented
N/A