### PR TITLE
Rpc options

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
   `"http-headers": map[string]string`
 
-  - Additional http headers to include in the API requests.
+  - Additional HTTP headers to include in the API requests.
 
 `"info-api": APIConfig`
 
@@ -156,7 +156,7 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
   `"http-headers": map[string]string`
 
-  - Additional http headers to include in the API requests.
+  - Additional HTTP headers to include in the API requests.
 
 `"storage-location": string`
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
   - Additional query parameters to include in the API requests.
 
+  `"http-headers": map[string]string`
+
+  - Additional http headers to include in the API requests.
+
 `"info-api": APIConfig`
 
 - The configuration for the Avalanche Info API node. The `InfoAPI` object has the following configuration:
@@ -149,6 +153,10 @@ The relayer is configured via a JSON file, the path to which is passed in via th
   `"query-parameters": map[string]string`
 
   - Additional query parameters to include in the API requests.
+
+  `"http-headers": map[string]string`
+
+  - Additional http headers to include in the API requests.
 
 `"storage-location": string`
 

--- a/config/config.go
+++ b/config/config.go
@@ -126,7 +126,7 @@ type WarpQuorum struct {
 type APIConfig struct {
 	BaseURL     string            `mapstructure:"base-url" json:"base-url"`
 	QueryParams map[string]string `mapstructure:"query-parameters" json:"query-parameters"`
-	HttpHeaders map[string]string `mapstructure:"http-headers" json:"http-headers"`
+	HTTPHeaders map[string]string `mapstructure:"http-headers" json:"http-headers"`
 }
 
 // Top-level configuration

--- a/config/config.go
+++ b/config/config.go
@@ -126,6 +126,7 @@ type WarpQuorum struct {
 type APIConfig struct {
 	BaseURL     string            `mapstructure:"base-url" json:"base-url"`
 	QueryParams map[string]string `mapstructure:"query-parameters" json:"query-parameters"`
+	HttpHeaders map[string]string `mapstructure:"http-headers" json:"http-headers"`
 }
 
 // Top-level configuration

--- a/config/test_utils.go
+++ b/config/test_utils.go
@@ -26,7 +26,7 @@ var (
 			QueryParams: map[string]string{
 				queryParamKey1: queryParamVal1,
 			},
-			HttpHeaders: map[string]string{
+			HTTPHeaders: map[string]string{
 				httpHeaderKey1: httpHeaderVal1,
 			},
 		},

--- a/config/test_utils.go
+++ b/config/test_utils.go
@@ -1,3 +1,5 @@
+//go:build testing
+
 package config
 
 import "fmt"

--- a/config/test_utils.go
+++ b/config/test_utils.go
@@ -1,5 +1,3 @@
-//go:build testing
-
 package config
 
 import "fmt"
@@ -13,6 +11,8 @@ var (
 	testPk2           string = "0x12389e99c94b6912bfc12adc093c9b51124f0dc54ac7a766b2bc5ccf558d8123"
 	queryParamKey1    string = "key1"
 	queryParamVal1    string = "val1"
+	httpHeaderKey1    string = "keyheader1"
+	httpHeaderVal1    string = "valheader1"
 )
 
 // Valid configuration objects to be used by tests in external packages
@@ -23,6 +23,9 @@ var (
 			BaseURL: "http://test.avax.network",
 			QueryParams: map[string]string{
 				queryParamKey1: queryParamVal1,
+			},
+			HttpHeaders: map[string]string{
+				httpHeaderKey1: httpHeaderVal1,
 			},
 		},
 		InfoAPI: &APIConfig{

--- a/peers/utils/utils.go
+++ b/peers/utils/utils.go
@@ -10,9 +10,12 @@ import (
 
 // InitializeOptions initializes the rpc options for an API
 func InitializeOptions(apiConfig *config.APIConfig) []rpc.Option {
-	options := make([]rpc.Option, 0, len(apiConfig.QueryParams))
+	options := make([]rpc.Option, 0, len(apiConfig.QueryParams)+len(apiConfig.HttpHeaders))
 	for key, value := range apiConfig.QueryParams {
 		options = append(options, rpc.WithQueryParam(key, value))
+	}
+	for key, value := range apiConfig.HttpHeaders {
+		options = append(options, rpc.WithHeader(key, value))
 	}
 	return options
 }

--- a/peers/utils/utils.go
+++ b/peers/utils/utils.go
@@ -10,11 +10,11 @@ import (
 
 // InitializeOptions initializes the rpc options for an API
 func InitializeOptions(apiConfig *config.APIConfig) []rpc.Option {
-	options := make([]rpc.Option, 0, len(apiConfig.QueryParams)+len(apiConfig.HttpHeaders))
+	options := make([]rpc.Option, 0, len(apiConfig.QueryParams)+len(apiConfig.HTTPHeaders))
 	for key, value := range apiConfig.QueryParams {
 		options = append(options, rpc.WithQueryParam(key, value))
 	}
-	for key, value := range apiConfig.HttpHeaders {
+	for key, value := range apiConfig.HTTPHeaders {
 		options = append(options, rpc.WithHeader(key, value))
 	}
 	return options


### PR DESCRIPTION
## Why this should be merged

Adding http-headers for p-chain and info-api clients.
Related to  https://github.com/ava-labs/awm-relayer/issues/186

## How this works

Use mechanism introduced in #268 to pass http-headers to p-chain & info-api clients.

## How this was tested

## How is this documented

Details of the new Config fields are added in the README.