### PR TITLE
Tag docker release as latest

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,9 +51,9 @@ docker_manifests:
     image_templates:
     - 'avaplatform/awm-relayer:{{ .Tag }}-amd64'
     - 'avaplatform/awm-relayer:{{ .Tag }}-arm64'
-# release:
-#   # Repo in which the release will be created.
-#   # Default is extracted from the origin remote URL or empty if its private hosted.
-#   github:
-#     owner: ava-labs
-#     name: awm-relayer
+release:
+  # Repo in which the release will be created.
+  # Default is extracted from the origin remote URL or empty if its private hosted.
+  github:
+    owner: ava-labs
+    name: awm-relayer

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,6 +31,7 @@ builds:
 dockers:
   - image_templates:
     - 'avaplatform/awm-relayer:{{ .Tag }}-amd64'
+    - 'avaplatform/awm-relayer:latest'
     use: buildx
     build_flag_templates:
     - "--pull"
@@ -38,6 +39,7 @@ dockers:
     - "--build-arg=GO_VERSION={{ .Env.GO_VERSION }}"
   - image_templates:
     - 'avaplatform/awm-relayer:{{ .Tag }}-arm64'
+    - 'avaplatform/awm-relayer:latest'
     use: buildx
     build_flag_templates:
     - "--pull"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,9 +51,9 @@ docker_manifests:
     image_templates:
     - 'avaplatform/awm-relayer:{{ .Tag }}-amd64'
     - 'avaplatform/awm-relayer:{{ .Tag }}-arm64'
-release:
-  # Repo in which the release will be created.
-  # Default is extracted from the origin remote URL or empty if its private hosted.
-  github:
-    owner: ava-labs
-    name: awm-relayer
+# release:
+#   # Repo in which the release will be created.
+#   # Default is extracted from the origin remote URL or empty if its private hosted.
+#   github:
+#     owner: ava-labs
+#     name: awm-relayer

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,7 +31,6 @@ builds:
 dockers:
   - image_templates:
     - 'avaplatform/awm-relayer:{{ .Tag }}-amd64'
-    - 'avaplatform/awm-relayer:latest'
     use: buildx
     build_flag_templates:
     - "--pull"
@@ -39,7 +38,6 @@ dockers:
     - "--build-arg=GO_VERSION={{ .Env.GO_VERSION }}"
   - image_templates:
     - 'avaplatform/awm-relayer:{{ .Tag }}-arm64'
-    - 'avaplatform/awm-relayer:latest'
     use: buildx
     build_flag_templates:
     - "--pull"
@@ -48,6 +46,10 @@ dockers:
     goarch: arm64
 docker_manifests:
   - name_template: 'avaplatform/awm-relayer:{{ .Tag }}'
+    image_templates:
+    - 'avaplatform/awm-relayer:{{ .Tag }}-amd64'
+    - 'avaplatform/awm-relayer:{{ .Tag }}-arm64'
+  - name_template: 'avaplatform/awm-relayer:latest'
     image_templates:
     - 'avaplatform/awm-relayer:{{ .Tag }}-amd64'
     - 'avaplatform/awm-relayer:{{ .Tag }}-arm64'


### PR DESCRIPTION
## Why this should be merged
Fixes #282 

## How this works
Adds configuration for a manifest named `latest` in `.goreleaser.yml`

## How this was tested
Manually tested with a dummy tag. See the workflow run here: https://github.com/ava-labs/awm-relayer/actions/runs/9020169707/job/24784727290, which pushed the manifests [latest](https://hub.docker.com/layers/avaplatform/awm-relayer/latest/images/sha256-e22fdfa8f5286604f352cac56ce6e677714f2b5432adaa70044113a692982916?context=explore) and [v1.2.1-test](https://hub.docker.com/layers/avaplatform/awm-relayer/v1.2.1-test/images/sha256-e22fdfa8f5286604f352cac56ce6e677714f2b5432adaa70044113a692982916?context=explore) to the dockerhub repo.

## How is this documented
N/A