### PR TITLE
Help option + fix unit test

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -6,6 +6,9 @@ name: Run Golang Linter
 on:
   push:
     branches:
+      - main
+  pull_request:
+    branches:
       - "**"
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ name: Tests
 on:
   push:
     branches:
+      - main
+  pull_request:
+    branches:
       - "**"
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ The Fuji and Mainnet [public API nodes](https://docs.avax.network/tooling/rpc-pr
 
 ## Usage
 
+### Options
+
+The relayer binary accepts the following command line options. Other configuration options are not supported via the command line and must be provided via the configuration JSON file or environment variable.
+
+```bash
+awm-relayer --config-file path-to-config                Specifies the relayer config file and begin relaying messages.
+awm-relayer --version                                   Display awm-relayer version and exit.
+awm-relayer --help                                      Display awm-relayer usage and exit.
+```
+
 ### Building
 
 Before building, be sure to install Go, which is required even if you're just building the Docker image.
@@ -98,14 +108,6 @@ Build a Docker image by running the script:
 
 ```bash
 ./scripts/build_local_image.sh
-```
-
-### Running
-
-The relayer binary accepts a path to a JSON configuration file as the sole argument. Command line configuration arguments are not currently supported.
-
-```bash
-./build/awm-relayer --config-file path-to-config
 ```
 
 ### Configuration

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,13 @@ const (
 	warpConfigKey               = "warpConfig"
 )
 
+const usageText = `
+Usage:
+awm-relayer --config-file path-to-config                Specifies the relayer config file and begin relaying messages.
+awm-relayer --version                                   Display awm-relayer version and exit.
+awm-relayer --help                                      Display awm-relayer usage and exit.
+`
+
 var errFailedToGetWarpQuorum = errors.New("failed to get warp quorum")
 
 // The generic configuration for a message protocol.
@@ -155,6 +162,10 @@ func SetDefaultConfigValues(v *viper.Viper) {
 	v.SetDefault(APIPortKey, 8080)
 	v.SetDefault(MetricsPortKey, 9090)
 	v.SetDefault(DBWriteIntervalSecondsKey, 10)
+}
+
+func DisplayUsageText() {
+	fmt.Printf("%s\n", usageText)
 }
 
 // BuildConfig constructs the relayer config using Viper.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -57,7 +57,10 @@ func runConfigModifierEnvVarTest(t *testing.T, testCase configMondifierEnvVarTes
 	testCase.envSetter()
 
 	fs := BuildFlagSet()
-	v, err := BuildViper(fs, flags)
+	if err := fs.Parse(flags); err != nil {
+		panic(fmt.Errorf("couldn't parse flags: %w", err))
+	}
+	v, err := BuildViper(fs)
 	require.NoError(t, err)
 	parsedCfg, optionOverwritten, err := BuildConfig(v)
 	require.NoError(t, err)

--- a/config/flags.go
+++ b/config/flags.go
@@ -9,5 +9,6 @@ func BuildFlagSet() *pflag.FlagSet {
 	fs := pflag.NewFlagSet("awm-relayer", pflag.ContinueOnError)
 	fs.String(ConfigFileKey, "", "Specifies the relayer config file")
 	fs.BoolP(VersionKey, "", false, "Display awm-relayer version")
+	fs.BoolP(HelpKey, "", false, "Display awm-relayer usage")
 	return fs
 }

--- a/config/keys.go
+++ b/config/keys.go
@@ -3,9 +3,13 @@
 
 package config
 
-// Top-level configuration keys
 const (
-	ConfigFileKey             = "config-file"
+	// Command line option keys
+	ConfigFileKey = "config-file"
+	VersionKey    = "version"
+	HelpKey       = "help"
+
+	// Top-level configuration keys
 	LogLevelKey               = "log-level"
 	PChainAPIKey              = "p-chain-api"
 	InfoAPIKey                = "info-api"
@@ -19,5 +23,4 @@ const (
 	ProcessMissedBlocksKey    = "process-missed-blocks"
 	ManualWarpMessagesKey     = "manual-warp-messages"
 	DBWriteIntervalSecondsKey = "db-write-interval-seconds"
-	VersionKey                = "version"
 )

--- a/config/viper.go
+++ b/config/viper.go
@@ -24,6 +24,7 @@ func BuildViper(fs *pflag.FlagSet) (*viper.Viper, error) {
 
 	// Verify required flags are set
 	if !v.IsSet(ConfigFileKey) {
+		DisplayUsageText()
 		return nil, fmt.Errorf("config file not set")
 	}
 

--- a/main/main.go
+++ b/main/main.go
@@ -36,6 +36,7 @@ var version = "v0.0.0-dev"
 func main() {
 	fs := config.BuildFlagSet()
 	if err := fs.Parse(os.Args[1:]); err != nil {
+		config.DisplayUsageText()
 		panic(fmt.Errorf("couldn't parse flags: %w", err))
 	}
 	// If the version flag is set, display the version then exit
@@ -47,6 +48,16 @@ func main() {
 		fmt.Printf("%s\n", version)
 		os.Exit(0)
 	}
+	// If the help flag is set, output the usage text then exit
+	help, err := fs.GetBool(config.HelpKey)
+	if err != nil {
+		panic(fmt.Errorf("error reading %s flag value: %w", config.HelpKey, err))
+	}
+	if help {
+		config.DisplayUsageText()
+		os.Exit(0)
+	}
+
 	v, err := config.BuildViper(fs)
 	if err != nil {
 		panic(fmt.Errorf("couldn't configure flags: %w", err))


### PR DESCRIPTION
## Why this should be merged
Fixes a unit test that was merged to main.
Modifies the lint and unit test CI jobs to run on PRs originating from forks.
Adds a `--help` option to display proper usage. Usage is displayed if incorrect flags are passed to the application.

## How this works
See above

## How this was tested
CI

## How is this documented
Updated README