### PR TITLE
Refactor application relayers

### DIFF
--- a/database/relayer_id.go
+++ b/database/relayer_id.go
@@ -53,7 +53,7 @@ func CalculateRelayerID(
 	sourceBlockchainID ids.ID,
 	destinationBlockchainID ids.ID,
 	originSenderAddress common.Address,
-	desinationAddress common.Address,
+	destinationAddress common.Address,
 ) common.Hash {
 	return crypto.Keccak256Hash(
 		[]byte(strings.Join(
@@ -61,7 +61,7 @@ func CalculateRelayerID(
 				sourceBlockchainID.String(),
 				destinationBlockchainID.String(),
 				originSenderAddress.String(),
-				desinationAddress.String(),
+				destinationAddress.String(),
 			},
 			"-",
 		)),

--- a/relayer/listener.go
+++ b/relayer/listener.go
@@ -52,7 +52,7 @@ func NewListener(
 	logger logging.Logger,
 	sourceBlockchain config.SourceBlockchain,
 	relayerHealth *atomic.Bool,
-	cfg *config.Config,
+	globalConfig *config.Config,
 	applicationRelayers map[common.Hash]*ApplicationRelayer,
 	startingHeight uint64,
 	ethClient ethclient.Client,
@@ -140,7 +140,7 @@ func NewListener(
 		sourceBlockchain:        sourceBlockchain,
 		catchUpResultChan:       catchUpResultChan,
 		healthStatus:            relayerHealth,
-		globalConfig:            cfg,
+		globalConfig:            globalConfig,
 		applicationRelayers:     applicationRelayers,
 		ethClient:               ethClient,
 	}

--- a/vms/evm/destination_client.go
+++ b/vms/evm/destination_client.go
@@ -46,7 +46,10 @@ type destinationClient struct {
 	logger                  logging.Logger
 }
 
-func NewDestinationClient(logger logging.Logger, destinationBlockchain *config.DestinationBlockchain) (*destinationClient, error) {
+func NewDestinationClient(
+	logger logging.Logger,
+	destinationBlockchain *config.DestinationBlockchain,
+) (*destinationClient, error) {
 	// Dial the destination RPC endpoint
 	client, err := ethclient.DialWithConfig(
 		context.Background(),
@@ -109,7 +112,8 @@ func NewDestinationClient(logger logging.Logger, destinationBlockchain *config.D
 	}, nil
 }
 
-func (c *destinationClient) SendTx(signedMessage *avalancheWarp.Message,
+func (c *destinationClient) SendTx(
+	signedMessage *avalancheWarp.Message,
 	toAddress string,
 	gasLimit uint64,
 	callData []byte,


### PR DESCRIPTION
## Why this should be merged
Integrates the first 3 bullet points from this comment https://github.com/ava-labs/awm-relayer/pull/288#discussion_r1619465642

## How this works
The main function now creates the application relayers instead of the listener. The application relayers are then passed to the listener instance.

## How this was tested

## How is this documented