### PR TITLE
downgrade processing block log

### DIFF
--- a/relayer/listener.go
+++ b/relayer/listener.go
@@ -269,7 +269,7 @@ func (lstnr *Listener) ProcessLogs(ctx context.Context) error {
 			}
 
 			// Relay the messages in the block to the destination chains. Continue on failure.
-			lstnr.logger.Info(
+			lstnr.logger.Debug(
 				"Processing block",
 				zap.String("sourceBlockchainID", lstnr.sourceBlockchain.GetBlockchainID().String()),
 				zap.Uint64("blockNumber", block.BlockNumber),


### PR DESCRIPTION
## Why this should be merged
Downgrades the per-block log to debug to reduce noise at the default log level (info)

## How this works

## How this was tested

## How is this documented