### PR TITLE
Log nonce usage

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,3 +59,5 @@ release:
   github:
     owner: ava-labs
     name: awm-relayer
+  # If tag indicates rc, will mark it as prerelease
+  prerelease: auto

--- a/vms/evm/destination_client.go
+++ b/vms/evm/destination_client.go
@@ -101,6 +101,13 @@ func NewDestinationClient(
 		return nil, err
 	}
 
+	logger.Info(
+		"Initialized destination client",
+		zap.String("blockchainID", destinationID.String()),
+		zap.String("evmChainID", evmChainID.String()),
+		zap.Uint64("nonce", nonce),
+	)
+
 	return &destinationClient{
 		client:                  client,
 		lock:                    new(sync.Mutex),
@@ -181,11 +188,12 @@ func (c *destinationClient) SendTx(
 		)
 		return err
 	}
-	c.currentNonce++
 	c.logger.Info(
 		"Sent transaction",
 		zap.String("txID", signedTx.Hash().String()),
+		zap.Uint64("nonce", c.currentNonce),
 	)
+	c.currentNonce++
 
 	return nil
 }


### PR DESCRIPTION
## Why this should be merged
Logs nonce usage to aid debugging.
Also enables support for prerelease tags (e.g. rc's)

## How this works

## How this was tested

## How is this documented