### PR TITLE
Bump Golang and Ubuntu

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   e2e_tests:
     name: e2e_tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout awm-relayer repository

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   golangci:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   golang-snyk:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   test_relayer:
     name: Unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout awm-relayer repository

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/awm-relayer
 
-go 1.21.10
+go 1.21.11
 
 require (
 	github.com/ava-labs/avalanche-network-runner v1.7.6


### PR DESCRIPTION
## Why this should be merged
Bumps the Golang version used by the relayer application, and bumps the Ubuntu versions that the Github actions run on.