### PR TITLE
Only require key to create signer

### DIFF
--- a/vms/evm/destination_client_test.go
+++ b/vms/evm/destination_client_test.go
@@ -29,7 +29,7 @@ var destinationSubnet = config.DestinationBlockchain{
 }
 
 func TestSendTx(t *testing.T) {
-	txSigner, err := signer.NewTxSigner(&destinationSubnet)
+	txSigner, err := signer.NewTxSigner(destinationSubnet.AccountPrivateKey)
 	require.NoError(t, err)
 
 	testError := fmt.Errorf("call errored")

--- a/vms/evm/signer/signer.go
+++ b/vms/evm/signer/signer.go
@@ -20,5 +20,5 @@ func NewSigner(destinationBlockchain *config.DestinationBlockchain) (Signer, err
 	if destinationBlockchain.AccountPrivateKey == "" {
 		return NewKMSSigner(destinationBlockchain.KMSAWSRegion, destinationBlockchain.KMSKeyID)
 	}
-	return NewTxSigner(destinationBlockchain)
+	return NewTxSigner(destinationBlockchain.AccountPrivateKey)
 }

--- a/vms/evm/signer/tx_signer.go
+++ b/vms/evm/signer/tx_signer.go
@@ -9,7 +9,6 @@ import (
 	"math/big"
 	"runtime"
 
-	"github.com/ava-labs/awm-relayer/config"
 	"github.com/ava-labs/awm-relayer/utils"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -23,8 +22,8 @@ type TxSigner struct {
 	eoa common.Address
 }
 
-func NewTxSigner(destinationBlockchain *config.DestinationBlockchain) (*TxSigner, error) {
-	pk, err := crypto.HexToECDSA(utils.SanitizeHexString(destinationBlockchain.AccountPrivateKey))
+func NewTxSigner(hexPrivateKey string) (*TxSigner, error) {
+	pk, err := crypto.HexToECDSA(utils.SanitizeHexString(hexPrivateKey))
 	if err != nil {
 		return nil, utils.ErrInvalidPrivateKeyHex
 	}

--- a/vms/evm/signer/tx_signer_test.go
+++ b/vms/evm/signer/tx_signer_test.go
@@ -56,7 +56,7 @@ func TestNewTxSigner(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			txSigner, err := NewTxSigner(&testCase.dst)
+			txSigner, err := NewTxSigner(testCase.dst.AccountPrivateKey)
 			require.Equal(t, testCase.expectedResult.err, err)
 			if err == nil {
 				require.Equal(t, testCase.expectedResult.pk.D.Int64(), txSigner.pk.D.Int64())


### PR DESCRIPTION
## Why this should be merged
Only the key is required to create the signer, so pass it in instead of a whole Source Subnet config object. This was helpful when trying to recreate a warp transaction that had failed.

## How this works

## How this was tested

## How is this documented