### PR TITLE
Warp API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ The Fuji and Mainnet [public API nodes](https://docs.avax.network/tooling/rpc-pr
 
 ### Peer-to-Peer Connections
 
-- The AWM relayer implementation gathers BLS signatures from the validators of the source Subnet via peer-to-peer `AppRequest` messages. Validator nodes need to be configured to accept incoming peer connections. Otherwise, the relayer will fail to gather Warp message signatures. For example, networking rules may need to be adjusted to allow traffic on the default AvalancheGo P2P port (9651), or the public IP may need to be manually set in the [node configuration](https://docs.avax.network/nodes/configure/avalanchego-config-flags#public-ip).
+- By default, the AWM relayer implementation gathers BLS signatures from the validators of the source Subnet via peer-to-peer `AppRequest` messages. Validator nodes need to be configured to accept incoming peer connections. Otherwise, the relayer will fail to gather Warp message signatures. For example, networking rules may need to be adjusted to allow traffic on the default AvalancheGo P2P port (9651), or the public IP may need to be manually set in the [node configuration](https://docs.avax.network/nodes/configure/avalanchego-config-flags#public-ip).
+- If configured to use the Warp API (see `warp-api-endpoint` in [Configuration](#configuration)) then aggregate signatures are fetched via a single RPC request, rather than `AppRequests` to individual validators. Note that the Warp API is disabled on the public API.
 
 ### Private Key Management
 
@@ -251,6 +252,10 @@ The relayer is configured via a JSON file, the path to which is passed in via th
   `"allowed-origin-sender-addresses": []string`
 
   - List of addresses on this source blockchain to relay Warp messages from. The sending address is defined by the message protocol. For example, it could be defined as the EOA that initiates the transaction, or the address that calls the message protocol contract. If empty, then all addresses are allowed.
+
+  `"warp-api-endpoint": APIConfig`
+
+  - The RPC endpoint configuration for the Warp API, which is used to fetch Warp aggregate signatures. If omitted, then signatures are fetched via AppRequest instead.
 
 `"destination-blockchains": []DestinationBlockchains`
 

--- a/config/destination_blockchain.go
+++ b/config/destination_blockchain.go
@@ -91,7 +91,7 @@ func (s *DestinationBlockchain) initializeWarpQuorum() error {
 		return fmt.Errorf("invalid subnetID in configuration. error: %w", err)
 	}
 
-	client, err := utils.DialWithConfig(context.Background(), s.RPCEndpoint.BaseURL, s.RPCEndpoint.HTTPHeaders, s.RPCEndpoint.QueryParams)
+	client, err := utils.NewEthClientWithConfig(context.Background(), s.RPCEndpoint.BaseURL, s.RPCEndpoint.HTTPHeaders, s.RPCEndpoint.QueryParams)
 	if err != nil {
 		return fmt.Errorf("failed to dial destination blockchain %s: %w", blockchainID, err)
 	}

--- a/main/main.go
+++ b/main/main.go
@@ -122,13 +122,14 @@ func main() {
 
 	// The app request network generates P2P networking logs that are verbose at the info level.
 	// Unless the log level is debug or lower, set the network log level to error to avoid spamming the logs.
+	// We do not collect metrics for the network.
 	networkLogLevel := logging.Error
 	if logLevel <= logging.Debug {
 		networkLogLevel = logLevel
 	}
 	network, err := peers.NewNetwork(
 		networkLogLevel,
-		registerer,
+		prometheus.DefaultRegisterer,
 		&cfg,
 	)
 	if err != nil {
@@ -181,7 +182,14 @@ func main() {
 	}
 
 	// Initialize message creator passed down to relayers for creating app requests.
-	messageCreator, err := message.NewCreator(logger, registerer, "message_creator", constants.DefaultNetworkCompressionType, constants.DefaultNetworkMaximumInboundTimeout)
+	// We do not collect metrics for the message creator.
+	messageCreator, err := message.NewCreator(
+		logger,
+		prometheus.DefaultRegisterer,
+		"message_creator",
+		constants.DefaultNetworkCompressionType,
+		constants.DefaultNetworkMaximumInboundTimeout,
+	)
 	if err != nil {
 		logger.Error(
 			"Failed to create message creator",

--- a/main/main.go
+++ b/main/main.go
@@ -243,7 +243,7 @@ func main() {
 		// errgroup will cancel the context when the first goroutine returns an error
 		errGroup.Go(func() error {
 			// Dial the eth client
-			ethClient, err := utils.DialWithConfig(
+			ethClient, err := utils.NewEthClientWithConfig(
 				context.Background(),
 				sourceBlockchain.RPCEndpoint.BaseURL,
 				sourceBlockchain.RPCEndpoint.HTTPHeaders,

--- a/relayer/application_relayer.go
+++ b/relayer/application_relayer.go
@@ -232,6 +232,7 @@ func (r *ApplicationRelayer) relayMessage(
 
 	// sourceWarpSignatureClient is nil iff the source blockchain is configured to fetch signatures via AppRequest
 	if r.sourceWarpSignatureClient == nil {
+		r.incFetchSignatureAppRequestCount()
 		signedMessage, err = r.createSignedMessageAppRequest(unsignedMessage, requestID)
 		if err != nil {
 			r.logger.Error(
@@ -242,6 +243,7 @@ func (r *ApplicationRelayer) relayMessage(
 			return err
 		}
 	} else {
+		r.incFetchSignatureRPCCount()
 		signedMessage, err = r.createSignedMessage(unsignedMessage)
 		if err != nil {
 			r.logger.Error(
@@ -749,4 +751,20 @@ func (r *ApplicationRelayer) setCreateSignedMessageLatencyMS(latency float64) {
 			r.relayerID.DestinationBlockchainID.String(),
 			r.sourceBlockchain.GetBlockchainID().String(),
 			r.sourceBlockchain.GetSubnetID().String()).Set(latency)
+}
+
+func (r *ApplicationRelayer) incFetchSignatureRPCCount() {
+	r.metrics.fetchSignatureRPCCount.
+		WithLabelValues(
+			r.relayerID.DestinationBlockchainID.String(),
+			r.sourceBlockchain.GetBlockchainID().String(),
+			r.sourceBlockchain.GetSubnetID().String()).Inc()
+}
+
+func (r *ApplicationRelayer) incFetchSignatureAppRequestCount() {
+	r.metrics.fetchSignatureAppRequestCount.
+		WithLabelValues(
+			r.relayerID.DestinationBlockchainID.String(),
+			r.sourceBlockchain.GetBlockchainID().String(),
+			r.sourceBlockchain.GetSubnetID().String()).Inc()
 }

--- a/relayer/application_relayer.go
+++ b/relayer/application_relayer.go
@@ -71,7 +71,7 @@ type ApplicationRelayer struct {
 	checkpointManager         *checkpoint.CheckpointManager
 	currentRequestID          uint32
 	lock                      *sync.RWMutex
-	sourceWarpSignatureClient *rpc.Client
+	sourceWarpSignatureClient *rpc.Client // nil if the source blockchain is configured to sign messages via AppRequest
 }
 
 func NewApplicationRelayer(

--- a/relayer/application_relayer_metrics.go
+++ b/relayer/application_relayer_metrics.go
@@ -14,9 +14,11 @@ var (
 )
 
 type ApplicationRelayerMetrics struct {
-	successfulRelayMessageCount  *prometheus.CounterVec
-	createSignedMessageLatencyMS *prometheus.GaugeVec
-	failedRelayMessageCount      *prometheus.CounterVec
+	successfulRelayMessageCount   *prometheus.CounterVec
+	createSignedMessageLatencyMS  *prometheus.GaugeVec
+	failedRelayMessageCount       *prometheus.CounterVec
+	fetchSignatureAppRequestCount *prometheus.CounterVec
+	fetchSignatureRPCCount        *prometheus.CounterVec
 }
 
 func NewApplicationRelayerMetrics(registerer prometheus.Registerer) (*ApplicationRelayerMetrics, error) {
@@ -53,9 +55,35 @@ func NewApplicationRelayerMetrics(registerer prometheus.Registerer) (*Applicatio
 	}
 	registerer.MustRegister(failedRelayMessageCount)
 
+	fetchSignatureAppRequestCount := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "fetch_signature_app_request_count",
+			Help: "Number messages signed via AppRequest",
+		},
+		[]string{"destination_chain_id", "source_chain_id", "source_subnet_id"},
+	)
+	if fetchSignatureAppRequestCount == nil {
+		return nil, ErrFailedToCreateApplicationRelayerMetrics
+	}
+	registerer.MustRegister(fetchSignatureAppRequestCount)
+
+	fetchSignatureRPCCount := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "fetch_signature_rpc_count",
+			Help: "Number messages signed via Warp API",
+		},
+		[]string{"destination_chain_id", "source_chain_id", "source_subnet_id"},
+	)
+	if fetchSignatureRPCCount == nil {
+		return nil, ErrFailedToCreateApplicationRelayerMetrics
+	}
+	registerer.MustRegister(fetchSignatureRPCCount)
+
 	return &ApplicationRelayerMetrics{
-		successfulRelayMessageCount:  successfulRelayMessageCount,
-		createSignedMessageLatencyMS: createSignedMessageLatencyMS,
-		failedRelayMessageCount:      failedRelayMessageCount,
+		successfulRelayMessageCount:   successfulRelayMessageCount,
+		createSignedMessageLatencyMS:  createSignedMessageLatencyMS,
+		failedRelayMessageCount:       failedRelayMessageCount,
+		fetchSignatureAppRequestCount: fetchSignatureAppRequestCount,
+		fetchSignatureRPCCount:        fetchSignatureRPCCount,
 	}, nil
 }

--- a/relayer/listener.go
+++ b/relayer/listener.go
@@ -66,7 +66,7 @@ func NewListener(
 		)
 		return nil, err
 	}
-	ethWSClient, err := utils.DialWithConfig(
+	ethWSClient, err := utils.NewEthClientWithConfig(
 		context.Background(),
 		sourceBlockchain.WSEndpoint.BaseURL,
 		sourceBlockchain.WSEndpoint.HTTPHeaders,

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -62,24 +62,24 @@ var _ = ginkgo.AfterSuite(func() {
 })
 
 var _ = ginkgo.Describe("[AWM Relayer Integration Tests", func() {
-	// ginkgo.It("Manually Provided Message", func() {
-	// 	ManualMessage(localNetworkInstance)
-	// })
-	// ginkgo.It("Basic Relay", func() {
-	// 	BasicRelay(localNetworkInstance)
-	// })
-	// ginkgo.It("Teleporter Registry", func() {
-	// 	TeleporterRegistry(localNetworkInstance)
-	// })
-	// ginkgo.It("Shared Database", func() {
-	// 	SharedDatabaseAccess(localNetworkInstance)
-	// })
-	// ginkgo.It("Allowed Addresses", func() {
-	// 	AllowedAddresses(localNetworkInstance)
-	// })
-	// ginkgo.It("Batch Message", func() {
-	// 	BatchRelay(localNetworkInstance)
-	// })
+	ginkgo.It("Manually Provided Message", func() {
+		ManualMessage(localNetworkInstance)
+	})
+	ginkgo.It("Basic Relay", func() {
+		BasicRelay(localNetworkInstance)
+	})
+	ginkgo.It("Teleporter Registry", func() {
+		TeleporterRegistry(localNetworkInstance)
+	})
+	ginkgo.It("Shared Database", func() {
+		SharedDatabaseAccess(localNetworkInstance)
+	})
+	ginkgo.It("Allowed Addresses", func() {
+		AllowedAddresses(localNetworkInstance)
+	})
+	ginkgo.It("Batch Message", func() {
+		BatchRelay(localNetworkInstance)
+	})
 	ginkgo.It("Warp API", func() {
 		WarpAPIRelay(localNetworkInstance)
 	})

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -80,4 +80,7 @@ var _ = ginkgo.Describe("[AWM Relayer Integration Tests", func() {
 	ginkgo.It("Batch Message", func() {
 		BatchRelay(localNetworkInstance)
 	})
+	ginkgo.It("Warp API", func() {
+		WarpAPIRelay(localNetworkInstance)
+	})
 })

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -62,24 +62,24 @@ var _ = ginkgo.AfterSuite(func() {
 })
 
 var _ = ginkgo.Describe("[AWM Relayer Integration Tests", func() {
-	ginkgo.It("Manually Provided Message", func() {
-		ManualMessage(localNetworkInstance)
-	})
-	ginkgo.It("Basic Relay", func() {
-		BasicRelay(localNetworkInstance)
-	})
-	ginkgo.It("Teleporter Registry", func() {
-		TeleporterRegistry(localNetworkInstance)
-	})
-	ginkgo.It("Shared Database", func() {
-		SharedDatabaseAccess(localNetworkInstance)
-	})
-	ginkgo.It("Allowed Addresses", func() {
-		AllowedAddresses(localNetworkInstance)
-	})
-	ginkgo.It("Batch Message", func() {
-		BatchRelay(localNetworkInstance)
-	})
+	// ginkgo.It("Manually Provided Message", func() {
+	// 	ManualMessage(localNetworkInstance)
+	// })
+	// ginkgo.It("Basic Relay", func() {
+	// 	BasicRelay(localNetworkInstance)
+	// })
+	// ginkgo.It("Teleporter Registry", func() {
+	// 	TeleporterRegistry(localNetworkInstance)
+	// })
+	// ginkgo.It("Shared Database", func() {
+	// 	SharedDatabaseAccess(localNetworkInstance)
+	// })
+	// ginkgo.It("Allowed Addresses", func() {
+	// 	AllowedAddresses(localNetworkInstance)
+	// })
+	// ginkgo.It("Batch Message", func() {
+	// 	BatchRelay(localNetworkInstance)
+	// })
 	ginkgo.It("Warp API", func() {
 		WarpAPIRelay(localNetworkInstance)
 	})

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -201,6 +201,7 @@ func CreateDefaultRelayerConfig(
 		StorageLocation:        StorageLocation,
 		DBWriteIntervalSeconds: DBUpdateSeconds,
 		ProcessMissedBlocks:    false,
+		MetricsPort:            9090,
 		SourceBlockchains:      sources,
 		DestinationBlockchains: destinations,
 	}

--- a/tests/warp_api.go
+++ b/tests/warp_api.go
@@ -1,0 +1,95 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package tests
+
+import (
+	"context"
+	"time"
+
+	testUtils "github.com/ava-labs/awm-relayer/tests/utils"
+	"github.com/ava-labs/teleporter/tests/interfaces"
+	"github.com/ava-labs/teleporter/tests/utils"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	. "github.com/onsi/gomega"
+)
+
+// This tests the basic functionality of the relayer using the Warp API/, rather than app requests. Includes:
+// - Relaying from Subnet A to Subnet B
+// - Relaying from Subnet B to Subnet A
+func WarpAPIRelay(network interfaces.LocalNetwork) {
+	subnetAInfo := network.GetPrimaryNetworkInfo()
+	subnetBInfo, _ := utils.GetTwoSubnets(network)
+	fundedAddress, fundedKey := network.GetFundedAccountInfo()
+	teleporterContractAddress := network.GetTeleporterContractAddress()
+	err := testUtils.ClearRelayerStorage()
+	Expect(err).Should(BeNil())
+
+	//
+	// Fund the relayer address on all subnets
+	//
+	ctx := context.Background()
+
+	log.Info("Funding relayer address on all subnets")
+	relayerKey, err := crypto.GenerateKey()
+	Expect(err).Should(BeNil())
+	testUtils.FundRelayers(ctx, []interfaces.SubnetTestInfo{subnetAInfo, subnetBInfo}, fundedKey, relayerKey)
+
+	//
+	// Set up relayer config
+	//
+	relayerConfig := testUtils.CreateDefaultRelayerConfig(
+		[]interfaces.SubnetTestInfo{subnetAInfo, subnetBInfo},
+		[]interfaces.SubnetTestInfo{subnetAInfo, subnetBInfo},
+		teleporterContractAddress,
+		fundedAddress,
+		relayerKey,
+	)
+	// Enable the Warp API for all source blockchains
+	for _, subnet := range relayerConfig.SourceBlockchains {
+		subnet.WarpAPIEndpoint = subnet.RPCEndpoint
+	}
+
+	relayerConfigPath := testUtils.WriteRelayerConfig(relayerConfig, testUtils.DefaultRelayerCfgFname)
+
+	//
+	// Test Relaying from Subnet A to Subnet B
+	//
+	log.Info("Test Relaying from Subnet A to Subnet B")
+
+	log.Info("Starting the relayer")
+	relayerCleanup := testUtils.BuildAndRunRelayerExecutable(ctx, relayerConfigPath)
+	defer relayerCleanup()
+
+	// Sleep for some time to make sure relayer has started up and subscribed.
+	log.Info("Waiting for the relayer to start up")
+	time.Sleep(15 * time.Second)
+
+	log.Info("Sending transaction from Subnet A to Subnet B")
+	testUtils.RelayBasicMessage(
+		ctx,
+		subnetAInfo,
+		subnetBInfo,
+		teleporterContractAddress,
+		fundedKey,
+		fundedAddress,
+	)
+
+	//
+	// Test Relaying from Subnet B to Subnet A
+	//
+	log.Info("Test Relaying from Subnet B to Subnet A")
+	testUtils.RelayBasicMessage(
+		ctx,
+		subnetBInfo,
+		subnetAInfo,
+		teleporterContractAddress,
+		fundedKey,
+		fundedAddress,
+	)
+
+	log.Info("Finished sending warp message, closing down output channel")
+	// Cancel the command and stop the relayer
+	relayerCleanup()
+}

--- a/tests/warp_api.go
+++ b/tests/warp_api.go
@@ -21,9 +21,13 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// Fully formed name of the metric that tracks the number aggregate signatures fetched from the Warp API
+const rpcSignatureMetricName = "app_fetch_signature_rpc_count"
+
 // This tests the basic functionality of the relayer using the Warp API/, rather than app requests. Includes:
 // - Relaying from Subnet A to Subnet B
 // - Relaying from Subnet B to Subnet A
+// - Verifying the messages were signed using the Warp API
 func WarpAPIRelay(network interfaces.LocalNetwork) {
 	subnetAInfo := network.GetPrimaryNetworkInfo()
 	subnetBInfo, _ := utils.GetTwoSubnets(network)
@@ -106,12 +110,11 @@ func WarpAPIRelay(network interfaces.LocalNetwork) {
 	Expect(err).Should(BeNil())
 	defer resp.Body.Close()
 
-	metricName := "app_fetch_signature_rpc_count"
 	var totalCount uint64
 	scanner := bufio.NewScanner(strings.NewReader(string(body)))
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.HasPrefix(line, metricName) {
+		if strings.HasPrefix(line, rpcSignatureMetricName) {
 			log.Info("Found metric line", "metric", line)
 			parts := strings.Fields(line)
 

--- a/utils/client_utils.go
+++ b/utils/client_utils.go
@@ -15,8 +15,17 @@ import (
 
 var ErrInvalidEndpoint = errors.New("invalid rpc endpoint")
 
-// DialWithContext returns an ethclient.Client with the internal RPC client configured with the provided options.
-func DialWithConfig(ctx context.Context, baseURL string, httpHeaders, queryParams map[string]string) (ethclient.Client, error) {
+// NewEthClientWithConfig returns an ethclient.Client with the internal RPC client configured with the provided options.
+func NewEthClientWithConfig(ctx context.Context, baseURL string, httpHeaders, queryParams map[string]string) (ethclient.Client, error) {
+	client, err := DialWithConfig(ctx, baseURL, httpHeaders, queryParams)
+	if err != nil {
+		return nil, err
+	}
+	return ethclient.NewClient(client), nil
+}
+
+// DialWithConfig dials the provided baseURL with the provided httpHeaders and queryParams
+func DialWithConfig(ctx context.Context, baseURL string, httpHeaders, queryParams map[string]string) (*rpc.Client, error) {
 	url, err := addQueryParams(baseURL, queryParams)
 	if err != nil {
 		return nil, err
@@ -25,7 +34,7 @@ func DialWithConfig(ctx context.Context, baseURL string, httpHeaders, queryParam
 	if err != nil {
 		return nil, err
 	}
-	return ethclient.NewClient(client), nil
+	return client, nil
 }
 
 // addQueryParams adds the query parameters to the url

--- a/vms/evm/destination_client.go
+++ b/vms/evm/destination_client.go
@@ -52,7 +52,7 @@ func NewDestinationClient(
 	destinationBlockchain *config.DestinationBlockchain,
 ) (*destinationClient, error) {
 	// Dial the destination RPC endpoint
-	client, err := utils.DialWithConfig(
+	client, err := utils.NewEthClientWithConfig(
 		context.Background(),
 		destinationBlockchain.RPCEndpoint.BaseURL,
 		destinationBlockchain.RPCEndpoint.HTTPHeaders,


### PR DESCRIPTION
## Why this should be merged
Fixe #119. Exposes config options to fetch Warp message aggregate signatures via the Warp API rather than app request.

## How this works
Adds `SourceBlockchain.WarpAPIEndpoint` config option. Internally, `ApplicationRelayers` are composed of `[rpc.Client](https://github.com/ava-labs/subnet-evm/blob/master/rpc/client.go)` rather than `[warp.Client](https://github.com/ava-labs/subnet-evm/blob/master/warp/client.go)`. This is because `warp.Client` does not presently support query params or http headers, and expects the URI to be in a specific form.

## How this was tested
Added Warp API e2e test.

## How is this documented
Updated README