### PR TITLE
Golang 1.21.12

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,19 +21,33 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-        
-      - name: Set Go version
-        run: |
-          source ./scripts/versions.sh
-          echo SUBNET_EVM_VERSION=$SUBNET_EVM_VERSION >> $GITHUB_ENV
 
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
 
+      - name: Set subnet-evm version
+        run: |
+          source ./scripts/versions.sh
+          echo SUBNET_EVM_VERSION=$SUBNET_EVM_VERSION >> $GITHUB_ENV
+
+      - name: Checkout subnet-evm repository
+        uses: actions/checkout@v4
+        with:
+          repository: ava-labs/subnet-evm
+          ref: ${{ env.SUBNET_EVM_VERSION }}
+
       - name: Install AvalancheGo Release
         run: BASEDIR=/tmp/e2e-test AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego ./scripts/install_avalanchego_release.sh
+
+      - name: Build Subnet-EVM Plugin Binary
+        run: ./scripts/build.sh /tmp/e2e-test/avalanchego/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
+
+      - name: Checkout awm-relayer repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Run E2E Tests
         run: AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego DATA_DIR=/tmp/e2e-test/data ./scripts/e2e_test.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,22 +32,8 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Checkout subnet-evm repository
-        uses: actions/checkout@v4
-        with:
-          repository: ava-labs/subnet-evm
-          ref: ${{ env.SUBNET_EVM_VERSION }}
-
       - name: Install AvalancheGo Release
         run: BASEDIR=/tmp/e2e-test AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego ./scripts/install_avalanchego_release.sh
-
-      - name: Build Subnet-EVM Plugin Binary
-        run: ./scripts/build.sh /tmp/e2e-test/avalanchego/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
-
-      - name: Checkout awm-relayer repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Run E2E Tests
         run: AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego DATA_DIR=/tmp/e2e-test/data ./scripts/e2e_test.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,13 +25,12 @@ jobs:
       - name: Set Go version
         run: |
           source ./scripts/versions.sh
-          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
           echo SUBNET_EVM_VERSION=$SUBNET_EVM_VERSION >> $GITHUB_ENV
 
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - name: Checkout subnet-evm repository
         uses: actions/checkout@v4

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -22,10 +22,6 @@ jobs:
       with:
           submodules: recursive
 
-    - name: Set Go version
-      run: |
-        source ./scripts/versions.sh
-
     - name: Setup Go
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,12 +25,11 @@ jobs:
     - name: Set Go version
       run: |
         source ./scripts/versions.sh
-        echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
 
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
 
     - name: Run Lint
       run: ./scripts/lint.sh --go-lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,6 @@ jobs:
           path: awm-relayer
           submodules: recursive
 
-      - name: Set Go version
-        run: |
-          source ./awm-relayer/scripts/versions.sh
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,12 @@ jobs:
           path: awm-relayer
           submodules: recursive
 
+      # The GO_VERSION must be set explicitly to be used by GoReleaser and in the Dockerfile.
+      - name: Set Go version
+        run: |
+          source ./awm-relayer/scripts/versions.sh
+          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,12 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          path: awm-relayer
           submodules: recursive
 
-      # The GO_VERSION must be set explicitly to be used by GoReleaser and in the Dockerfile.
+      # The GO_VERSION must be set explicitly to be used in the Dockerfile.
       - name: Set Go version
         run: |
-          source ./awm-relayer/scripts/versions.sh
+          source ./scripts/versions.sh
           echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
 
       - name: Set up Go
@@ -71,8 +69,6 @@ jobs:
           distribution: goreleaser
           version: latest
           args: release --clean
-          workdir: ./awm-relayer/
         env:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GO_VERSION: ${{ env.GO_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,11 @@ jobs:
       - name: Set Go version
         run: |
           source ./awm-relayer/scripts/versions.sh
-          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - name: Set up arm64 cross compiler
         run: |

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          path: awm-relayer
           submodules: recursive
 
       - name: Run Snyk

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,12 +25,11 @@ jobs:
       - name: Set Go version
         run: |
           source ./scripts/versions.sh
-          echo GO_VERSION=$GO_VERSION >> $GITHUB_ENV
           
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - name: Run Relayer Unit Tests
         run: ./scripts/test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-        
-      - name: Set Go version
-        run: |
-          source ./scripts/versions.sh
           
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-To start developing on AWM Relayer, you'll need Golang >= v1.21.7.
+To start developing on AWM Relayer, you'll need Golang v1.21.12.
 
 ## Issues
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/awm-relayer
 
-go 1.21.11
+go 1.21.12
 
 require (
 	github.com/ava-labs/avalanche-network-runner v1.7.6


### PR DESCRIPTION
## Why this should be merged

Bump to latest 1.21 Golang release. Removes unnecessary explicit version used by actions/setup-go in favor of pulling directly from go.mod.