### PR TITLE
Add osxcross to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ server.log
 # Foundry outputs
 cache/
 out/
+
+# Release build outputs
+osxcross/


### PR DESCRIPTION
## Why this should be merged

Should fix the release workflow (current error seen [here](https://github.com/ava-labs/awm-relayer/actions/runs/9811964547/job/27098592954#step:11:27)).

## How this works

The issue was introduced by this PR which no longer cloned the `awm-relayer` repo into it's own subdirectory, making the working directory the repository itself.

Documentation on the exact `goreleaser` error is [here](https://goreleaser.com/errors/dirty/).