### PR TITLE
Decode hex or cb58

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,11 +199,11 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
   `"source-blockchain-id": string`
 
-  - cb58-encoded blockchain ID of the source blockchain.
+  - Hex or cb58-encoded blockchain ID of the source blockchain.
 
   `"destination-blockchain-id": string`
 
-  - cb58-encoded blockchain ID of the destination blockchain.
+  - Hex or cb58-encoded blockchain ID of the destination blockchain.
 
   `"source-address": string`
 

--- a/README.md
+++ b/README.md
@@ -199,11 +199,11 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
   `"source-blockchain-id": string`
 
-  - Hex or cb58-encoded blockchain ID of the source blockchain.
+  - cb58 encoded or "0x" prefixed Hex encoded blockchain ID of the source blockchain.
 
   `"destination-blockchain-id": string`
 
-  - Hex or cb58-encoded blockchain ID of the destination blockchain.
+  - cb58 encoded or "0x" prefixed Hex encoded blockchain ID of the destination blockchain.
 
   `"source-address": string`
 

--- a/README.md
+++ b/README.md
@@ -199,11 +199,11 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
   `"source-blockchain-id": string`
 
-  - cb58 encoded or "0x" prefixed Hex encoded blockchain ID of the source blockchain.
+  - cb58-encoded or "0x" prefixed hex-encoded blockchain ID of the source blockchain.
 
   `"destination-blockchain-id": string`
 
-  - cb58 encoded or "0x" prefixed Hex encoded blockchain ID of the destination blockchain.
+  - cb58-encoded or "0x" prefixed hex-encoded blockchain ID of the destination blockchain.
 
   `"source-address": string`
 
@@ -219,11 +219,11 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
   `"subnet-id": string`
 
-  - cb58-encoded Subnet ID.
+  - cb58-encoded or "0x" prefixed hex-encoded Subnet ID.
 
   `"blockchain-id": string`
 
-  - cb58-encoded blockchain ID.
+  - cb58-encoded or "0x" prefixed hex-encoded blockchain ID.
 
   `"vm": string`
 
@@ -263,11 +263,11 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
   `"subnet-id": string`
 
-  - cb58-encoded Subnet ID.
+  - cb58-encoded or "0x" prefixed hex-encoded Subnet ID.
 
   `"blockchain-id": string`
 
-  - cb58-encoded blockchain ID.
+  - cb58-encoded or "0x" prefixed hex-encoded blockchain ID.
 
   `"vm": string`
 
@@ -322,8 +322,8 @@ The relayer consists of the following components:
 - Used to manually relay a Warp message. The body of the request must contain the following JSON:
 ```json
 {
- "blockchain-id": "<cb58-encoding of blockchain ID>",
- "message-id": "<cb58-encoding of Warp message ID>",
+ "blockchain-id": "<cb58-encoded or '0x' prefixed hex-encoded of blockchain ID>",
+ "message-id": "<cb58-encoded or '0x' prefixed hex-encoded of Warp message ID>",
  "block-num": "<Block number that the message was sent in>"
 }
 ```

--- a/api/relay_message.go
+++ b/api/relay_message.go
@@ -5,11 +5,10 @@ import (
 	"math/big"
 	"net/http"
 
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/awm-relayer/relayer"
 	"github.com/ava-labs/awm-relayer/types"
-	relayerTypes "github.com/ava-labs/awm-relayer/types"
+	"github.com/ava-labs/awm-relayer/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"go.uber.org/zap"
 )
@@ -20,9 +19,9 @@ const (
 )
 
 type RelayMessageRequest struct {
-	// Required. cb58 encoding of the source blockchain ID for the message
+	// Required. Hex or cb58 encoding of the source blockchain ID for the message
 	BlockchainID string `json:"blockchain-id"`
-	// Required. cb58 encoding of the warp message ID
+	// Required. Hex or cb58 encoding of the warp message ID
 	MessageID string `json:"message-id"`
 	// Required. Block number that the message was sent in
 	BlockNum uint64 `json:"block-num"`
@@ -64,7 +63,7 @@ func relayMessageAPIHandler(logger logging.Logger, messageCoordinator *relayer.M
 			return
 		}
 
-		warpMessageInfo := &relayerTypes.WarpMessageInfo{
+		warpMessageInfo := &types.WarpMessageInfo{
 			SourceAddress:   common.HexToAddress(req.SourceAddress),
 			UnsignedMessage: unsignedMessage,
 		}
@@ -104,13 +103,13 @@ func relayAPIHandler(logger logging.Logger, messageCoordinator *relayer.MessageC
 			return
 		}
 
-		blockchainID, err := ids.FromString(req.BlockchainID)
+		blockchainID, err := utils.HexOrCB58ToID(req.BlockchainID)
 		if err != nil {
 			logger.Warn("Invalid blockchainID", zap.String("blockchainID", req.BlockchainID))
 			http.Error(w, "invalid blockchainID: "+err.Error(), http.StatusBadRequest)
 			return
 		}
-		messageID, err := ids.FromString(req.MessageID)
+		messageID, err := utils.HexOrCB58ToID(req.MessageID)
 		if err != nil {
 			logger.Warn("Invalid messageID", zap.String("messageID", req.MessageID))
 			http.Error(w, "invalid messageID: "+err.Error(), http.StatusBadRequest)

--- a/api/relay_message.go
+++ b/api/relay_message.go
@@ -19,9 +19,9 @@ const (
 )
 
 type RelayMessageRequest struct {
-	// Required. Hex or cb58 encoding of the source blockchain ID for the message
+	// Required. cb58 encoding or "0x" prefixed Hex encoding of the source blockchain ID for the message
 	BlockchainID string `json:"blockchain-id"`
-	// Required. Hex or cb58 encoding of the warp message ID
+	// Required. cb58 encoding or "0x" prefixed Hex encoding of the warp message ID
 	MessageID string `json:"message-id"`
 	// Required. Block number that the message was sent in
 	BlockNum uint64 `json:"block-num"`

--- a/api/relay_message.go
+++ b/api/relay_message.go
@@ -19,9 +19,9 @@ const (
 )
 
 type RelayMessageRequest struct {
-	// Required. cb58 encoding or "0x" prefixed Hex encoding of the source blockchain ID for the message
+	// Required. cb58-encoded or "0x" prefixed hex-encoded source blockchain ID for the message
 	BlockchainID string `json:"blockchain-id"`
-	// Required. cb58 encoding or "0x" prefixed Hex encoding of the warp message ID
+	// Required. cb58-encoded or "0x" prefixed hex-encoded warp message ID
 	MessageID string `json:"message-id"`
 	// Required. Block number that the message was sent in
 	BlockNum uint64 `json:"block-num"`

--- a/config/destination_blockchain.go
+++ b/config/destination_blockchain.go
@@ -29,8 +29,8 @@ type DestinationBlockchain struct {
 	blockchainID ids.ID
 }
 
-// Validatees the destination subnet configuration
-func (s *DestinationBlockchain) Validate() error { 
+// Validates the destination subnet configuration
+func (s *DestinationBlockchain) Validate() error {
 	if err := s.RPCEndpoint.Validate(); err != nil {
 		return fmt.Errorf("invalid rpc-endpoint in destination subnet configuration: %w", err)
 	}

--- a/config/destination_blockchain.go
+++ b/config/destination_blockchain.go
@@ -30,16 +30,7 @@ type DestinationBlockchain struct {
 }
 
 // Validatees the destination subnet configuration
-func (s *DestinationBlockchain) Validate() error {
-	if _, err := ids.FromString(s.SubnetID); err != nil {
-		return fmt.Errorf("invalid subnetID in destination subnet configuration. Provided ID: %s", s.SubnetID)
-	}
-	if _, err := ids.FromString(s.BlockchainID); err != nil {
-		return fmt.Errorf(
-			"invalid blockchainID in destination subnet configuration. Provided ID: %s",
-			s.BlockchainID,
-		)
-	}
+func (s *DestinationBlockchain) Validate() error { 
 	if err := s.RPCEndpoint.Validate(); err != nil {
 		return fmt.Errorf("invalid rpc-endpoint in destination subnet configuration: %w", err)
 	}
@@ -63,14 +54,14 @@ func (s *DestinationBlockchain) Validate() error {
 	}
 
 	// Validate and store the subnet and blockchain IDs for future use
-	blockchainID, err := ids.FromString(s.BlockchainID)
+	blockchainID, err := utils.HexOrCB58ToID(s.BlockchainID)
 	if err != nil {
-		return fmt.Errorf("invalid blockchainID in configuration. error: %w", err)
+		return fmt.Errorf("invalid blockchainID '%s' in configuration. error: %w", s.BlockchainID, err)
 	}
 	s.blockchainID = blockchainID
-	subnetID, err := ids.FromString(s.SubnetID)
+	subnetID, err := utils.HexOrCB58ToID(s.SubnetID)
 	if err != nil {
-		return fmt.Errorf("invalid subnetID in configuration. error: %w", err)
+		return fmt.Errorf("invalid subnetID '%s' in configuration. error: %w", s.SubnetID, err)
 	}
 	s.subnetID = subnetID
 

--- a/config/source_blockchain.go
+++ b/config/source_blockchain.go
@@ -37,12 +37,6 @@ type SourceBlockchain struct {
 // destinationBlockchainIDs. Does not modify the public fields as derived from the configuration passed to the
 // application, but does initialize private fields available through getters.
 func (s *SourceBlockchain) Validate(destinationBlockchainIDs *set.Set[string]) error {
-	if _, err := ids.FromString(s.SubnetID); err != nil {
-		return fmt.Errorf("invalid subnetID in source subnet configuration. Provided ID: %s", s.SubnetID)
-	}
-	if _, err := ids.FromString(s.BlockchainID); err != nil {
-		return fmt.Errorf("invalid blockchainID in source subnet configuration. Provided ID: %s", s.BlockchainID)
-	}
 	if err := s.RPCEndpoint.Validate(); err != nil {
 		return fmt.Errorf("invalid rpc-endpoint in source subnet configuration: %w", err)
 	}
@@ -79,14 +73,14 @@ func (s *SourceBlockchain) Validate(destinationBlockchainIDs *set.Set[string]) e
 	}
 
 	// Validate and store the subnet and blockchain IDs for future use
-	blockchainID, err := ids.FromString(s.BlockchainID)
+	blockchainID, err := utils.HexOrCB58ToID(s.BlockchainID)
 	if err != nil {
-		return fmt.Errorf("invalid blockchainID in configuration. error: %w", err)
+		return fmt.Errorf("invalid blockchainID '%s' in configuration. error: %w", s.BlockchainID, err)
 	}
 	s.blockchainID = blockchainID
-	subnetID, err := ids.FromString(s.SubnetID)
+	subnetID, err := utils.HexOrCB58ToID(s.SubnetID)
 	if err != nil {
-		return fmt.Errorf("invalid subnetID in configuration. error: %w", err)
+		return fmt.Errorf("invalid subnetID '%s' in configuration. error: %w", s.SubnetID, err)
 	}
 	s.subnetID = subnetID
 
@@ -99,7 +93,7 @@ func (s *SourceBlockchain) Validate(destinationBlockchainIDs *set.Set[string]) e
 		}
 	}
 	for _, dest := range s.SupportedDestinations {
-		blockchainID, err := ids.FromString(dest.BlockchainID)
+		blockchainID, err := utils.HexOrCB58ToID(dest.BlockchainID)
 		if err != nil {
 			return fmt.Errorf("invalid blockchainID in configuration. error: %w", err)
 		}
@@ -107,7 +101,8 @@ func (s *SourceBlockchain) Validate(destinationBlockchainIDs *set.Set[string]) e
 			return fmt.Errorf(
 				"configured source subnet %s has a supported destination blockchain ID %s that is not configured as a destination blockchain", //nolint:lll
 				s.SubnetID,
-				blockchainID)
+				blockchainID,
+			)
 		}
 		dest.blockchainID = blockchainID
 		for _, addressStr := range dest.Addresses {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -122,4 +123,16 @@ func StripFromString(input, substring string) string {
 	strippedString := input[:index]
 
 	return strippedString
+}
+
+// Converts a '0x'-prefixed hex string or cb58-encoded string to an ID.
+func HexOrCB58ToID(s string) (ids.ID, error) {
+	if strings.HasPrefix(s, "0x") {
+		bytes, err := hex.DecodeString(SanitizeHexString(s))
+		if err != nil {
+			return ids.ID{}, err
+		}
+		return ids.ToID(bytes)
+	}
+	return ids.FromString(s)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -126,6 +126,7 @@ func StripFromString(input, substring string) string {
 }
 
 // Converts a '0x'-prefixed hex string or cb58-encoded string to an ID.
+// Input length validation is handled by the ids package.
 func HexOrCB58ToID(s string) (ids.ID, error) {
 	if strings.HasPrefix(s, "0x") {
 		bytes, err := hex.DecodeString(SanitizeHexString(s))

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -10,6 +10,44 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestHexOrCB58ToID(t *testing.T) {
+	testCases := []struct {
+		name           string
+		encoding       string
+		expectedResult string
+		errorExpected  bool
+	}{
+		{
+			name:           "hex conversion",
+			encoding:       "0x7fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d5",
+			expectedResult: "yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp",
+			errorExpected:  false,
+		},
+		{
+			name:           "cb58 conversion",
+			encoding:       "yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp",
+			expectedResult: "yH8D7ThNJkxmtkuv2jgBa4P1Rn3Qpr4pPr7QYNfcdoS6k6HWp",
+			errorExpected:  false,
+		},
+		{
+			name:          "non-prefixed hex",
+			encoding:      "7fc93d85c6d62c5b2ac0b519c87010ea5294012d1e407030d6acd0021cac10d5",
+			errorExpected: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actualResult, err := HexOrCB58ToID(testCase.encoding)
+			if testCase.errorExpected {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, testCase.expectedResult, actualResult.String())
+			}
+		})
+	}
+}
+
 func TestSanitizeHexString(t *testing.T) {
 	testCases := []struct {
 		name           string


### PR DESCRIPTION
## Why this should be merged
Closes https://github.com/ava-labs/awm-relayer/issues/355

## How this works
If the string is prepended by '0x', attempts to decode from hex. Otherwise, tries to decode as cb58. The checksum in cb58 should prevent accidental collisions.

## How this was tested
Unit tests added

## How is this documented
Added hex as option in README