### PR TITLE
e2e tests: use fewer nodes

### DIFF
--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -41,12 +41,12 @@ var _ = ginkgo.BeforeSuite(func() {
 			{
 				Name:       "A",
 				EVMChainID: 12345,
-				NodeCount:  5,
+				NodeCount:  2,
 			},
 			{
 				Name:       "B",
 				EVMChainID: 54321,
-				NodeCount:  5,
+				NodeCount:  2,
 			},
 		},
 		0,


### PR DESCRIPTION
## Why this should be merged
Because it reduced my test run time from 5m10s to 4m45s, an 8% reduction.

## How this was tested
By running the existing tests.