### PR TITLE
workflows: add buf linter for proto files

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,6 +12,17 @@ on:
       - "**"
 
 jobs:
+  buf-lint:
+    name: Protobuf Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-setup-action@v1.31.0
+        with:
+          github_token: ${{ github.token }}
+      - uses: bufbuild/buf-lint-action@v1
+        with:
+          input: "proto"
   golangci:
     runs-on: ubuntu-22.04
     timeout-minutes: 10

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,12 +14,10 @@ on:
 jobs:
   buf-lint:
     name: Protobuf Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-setup-action@v1.31.0
-        with:
-          github_token: ${{ github.token }}
+      - uses: bufbuild/buf-setup-action@v1.35.1
       - uses: bufbuild/buf-lint-action@v1
         with:
           input: "proto"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,7 +1,7 @@
 # Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 # See the file LICENSE for licensing terms.
 
-name: Run Golang Linter
+name: Run Buf and Golang Linter
 
 on:
   push:


### PR DESCRIPTION
## Why this should be merged

Closes #402 
This adds a new job using bug linter on proto files

## How this works

It uses the `bufbuild` github actions to setup buf cli and run linter on `proto` directory.

## How this was tested

it has been tested locally using `act`.
-> with current proto files:  No lint errors were found.
-> introducing an error in decider.proto, it logs:
```
::error file=proto/decider/decider.proto,line=15,col=32::syntax error: unexpected ';', expecting int literal
::error::buf found 1 lint failures.
```

## How is this documented