### PR TITLE
config: check tracked subnets does not exceed the limit

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ const (
 	accountPrivateKeyEnvVarName = "ACCOUNT_PRIVATE_KEY"
 	cChainIdentifierString      = "C"
 	warpConfigKey               = "warpConfig"
+	suppliedSubnetsLimit        = 16
 )
 
 const (
@@ -70,12 +71,23 @@ func DisplayUsageText() {
 	fmt.Printf("%s\n", usageText)
 }
 
+func (c *Config) countSuppliedSubnets() int {
+	foundSubnets := make(map[string]struct{})
+	for _, sourceBlockchain := range c.SourceBlockchains {
+		foundSubnets[sourceBlockchain.SubnetID] = struct{}{}
+	}
+	return len(foundSubnets)
+}
+
 // Validates the configuration
 // Does not modify the public fields as derived from the configuration passed to the application,
 // but does initialize private fields available through getters.
 func (c *Config) Validate() error {
 	if len(c.SourceBlockchains) == 0 {
 		return errors.New("relayer not configured to relay from any subnets. A list of source subnets must be provided in the configuration file") //nolint:lll
+	}
+	if suppliedSubnets := c.countSuppliedSubnets(); suppliedSubnets > suppliedSubnetsLimit {
+		return fmt.Errorf("relayer can track at most %d subnets, %d are provided", suppliedSubnetsLimit, suppliedSubnets)
 	}
 	if len(c.DestinationBlockchains) == 0 {
 		return errors.New("relayer not configured to relay to any subnets. A list of destination subnets must be provided in the configuration file") //nolint:lll

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -462,3 +462,20 @@ func TestValidateSourceBlockchain(t *testing.T) {
 		})
 	}
 }
+
+func TestCountSuppliedSubnets(t *testing.T) {
+	config := Config{
+		SourceBlockchains: []*SourceBlockchain{
+			{
+				SubnetID: "1",
+			},
+			{
+				SubnetID: "2",
+			},
+			{
+				SubnetID: "1",
+			},
+		},
+	}
+	require.Equal(t, 2, config.countSuppliedSubnets())
+}


### PR DESCRIPTION
## Why this should be merged

Closes #399 

## How this works

This checks that the provided subnets does not exceed the limit (16) and returns error during config validation when exceeding.

## How this was tested

unit test has been added

## How is this documented