### PR TITLE
Add explicit gas check

### DIFF
--- a/messages/teleporter/message_handler.go
+++ b/messages/teleporter/message_handler.go
@@ -29,6 +29,10 @@ import (
 	"google.golang.org/grpc"
 )
 
+// The maximum gas limit that can be specified for a Teleporter message
+// Based on the C-Chain 15_000_000 gas limit per block, with other Warp message gas overhead conservatively estimated.
+const maxTeleporterGasLimit = 12_000_000
+
 type factory struct {
 	messageConfig   Config
 	protocolAddress common.Address
@@ -159,6 +163,19 @@ func (m *messageHandler) ShouldSendMessage(destinationClient vms.DestinationClie
 		return false, fmt.Errorf("failed to calculate Teleporter message ID: %w", err)
 	}
 
+	// Check if the specified gas limit is below the maximum threshold
+	if m.teleporterMessage.RequiredGasLimit.Uint64() > maxTeleporterGasLimit {
+		m.logger.Info(
+			"Gas limit exceeds maximum threshold",
+			zap.String("destinationBlockchainID", destinationBlockchainID.String()),
+			zap.String("teleporterMessageID", teleporterMessageID.String()),
+			zap.Uint64("requiredGasLimit", m.teleporterMessage.RequiredGasLimit.Uint64()),
+			zap.Uint64("maxGasLimit", maxTeleporterGasLimit),
+		)
+		return false, nil
+	}
+
+	// Check if the relayer is allowed to deliver this message
 	senderAddress := destinationClient.SenderAddress()
 	if !isAllowedRelayer(m.teleporterMessage.AllowedRelayerAddresses, senderAddress) {
 		m.logger.Info(
@@ -191,6 +208,7 @@ func (m *messageHandler) ShouldSendMessage(destinationClient vms.DestinationClie
 		)
 		return false, nil
 	}
+
 	// Dispatch to the external decider service. If the service is unavailable or returns
 	// an error, then use the decision that has already been made, i.e. return true
 	decision, err := m.getShouldSendMessageFromDecider()

--- a/messages/teleporter/message_handler_test.go
+++ b/messages/teleporter/message_handler_test.go
@@ -116,6 +116,25 @@ func TestShouldSendMessage(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	gasLimitExceededTeleporterMessage := validTeleporterMessage
+	gasLimitExceededTeleporterMessage.RequiredGasLimit = big.NewInt(maxTeleporterGasLimit + 1)
+	gasLimitExceededTeleporterMessageBytes, err :=
+		teleportermessenger.PackTeleporterMessage(gasLimitExceededTeleporterMessage)
+	require.NoError(t, err)
+
+	gasLimitExceededAddressedCall, err := warpPayload.NewAddressedCall(
+		messageProtocolAddress.Bytes(),
+		gasLimitExceededTeleporterMessageBytes,
+	)
+	require.NoError(t, err)
+
+	gasLimitExceededWarpUnsignedMessage, err := warp.NewUnsignedMessage(
+		0,
+		sourceBlockchainID,
+		gasLimitExceededAddressedCall.Bytes(),
+	)
+	require.NoError(t, err)
+
 	testCases := []struct {
 		name                    string
 		destinationBlockchainID ids.ID
@@ -176,6 +195,12 @@ func TestShouldSendMessage(t *testing.T) {
 				times:          1,
 			},
 			expectedResult: false,
+		},
+		{
+			name:                    "gas limit exceeded",
+			destinationBlockchainID: destinationBlockchainID,
+			warpUnsignedMessage:     gasLimitExceededWarpUnsignedMessage,
+			expectedResult:          false,
 		},
 	}
 	for _, test := range testCases {

--- a/tests/batch_relay.go
+++ b/tests/batch_relay.go
@@ -83,7 +83,7 @@ func BatchRelay(network interfaces.LocalNetwork) {
 	Expect(err).Should(BeNil())
 	defer sub.Unsubscribe()
 
-	numMessages := 50
+	numMessages := 40
 	sentMessages := set.NewSet[string](numMessages)
 	for i := 0; i < numMessages; i++ {
 		sentMessages.Add(strconv.Itoa(i))


### PR DESCRIPTION
## Why this should be merged
Adds an explicit check against the gas limit specified in the Teleporter message.

It's possible for the required gas limit in a Teleporter message to exceed the block gas limit. This causes the transaction to fail as expected, but also causes the relayer to enter an unhealthy state, preventing it from updating the checkpoint in its database. This can cause compounding latency that will eventually prevent the relayer from running at all.

## How this works
Generally speaking, such validity checks are done in `ShouldSendMessage` and the `Decider` service. This is done before 
signature aggregation, to short circuit that step if the message is invalid. However, the number of signers impacts the gas estimation, so we can't use that in `ShouldSendMessage`. Instead, I added a hard cap of 12 million gas, which is the C-Chain's 15 million gas block limit minus other Warp message related overhead that is conservatively estimated. Specifically, the 12 million figure assumes:
- 10kb Warp message size
- 8kb Teleporter message size
- 1000 signing validators
- 5 Teleporter receipts (the maximum amount)

## How this was tested
CI, updated unit tests

## How is this documented
N/A