### PR TITLE
Downgrade conn/disconn logs

### DIFF
--- a/peers/external_handler.go
+++ b/peers/external_handler.go
@@ -96,7 +96,7 @@ func (h *RelayerExternalHandler) HandleInbound(_ context.Context, inboundMessage
 }
 
 func (h *RelayerExternalHandler) Connected(nodeID ids.NodeID, version *version.Application, subnetID ids.ID) {
-	h.log.Info(
+	h.log.Debug(
 		"Connected",
 		zap.Stringer("nodeID", nodeID),
 		zap.Stringer("version", version),
@@ -105,7 +105,7 @@ func (h *RelayerExternalHandler) Connected(nodeID ids.NodeID, version *version.A
 }
 
 func (h *RelayerExternalHandler) Disconnected(nodeID ids.NodeID) {
-	h.log.Info(
+	h.log.Debug(
 		"Disconnected",
 		zap.Stringer("nodeID", nodeID),
 	)


### PR DESCRIPTION
## Why this should be merged
The external handler connected/disconnected logs flood the log output when the default log level (info) is used. This PR downgrades those logs to debug.

## How this works

## How this was tested

## How is this documented