### PR TITLE
Tracked subnets fix

### DIFF
--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -143,6 +143,9 @@ func main() {
 	// TODO: remove this from here once trackedSubnets are no longer referenced
 	// by ping messages in avalanchego
 	for _, sourceBlockchain := range cfg.SourceBlockchains {
+		if sourceBlockchain.GetSubnetID() == constants.PrimaryNetworkID {
+			continue
+		}
 		trackedSubnets.Add(sourceBlockchain.GetSubnetID())
 	}
 


### PR DESCRIPTION
## Why this should be merged

As of `avalanchego v1.11.7` it's no longer valid for nodes to set the primary network ID in their tracked subnets. Setting it anyway causes peers to disconnect from the relayer at the 22.5 second Ping interval. 

## How this works

Only sets non-primary networkIDs as tracked subnets

## How this was tested

Manually ran a relayer connected to fuji/echo/dispatch and confirmed that there are no disconnects when looking at the logs after this fix and there are without it. 

## How is this documented

N/A