### PR TITLE
add metrics for connect/disconnect events

### DIFF
--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -61,7 +61,7 @@ func NewNetwork(
 	}
 
 	// Create the handler for handling inbound app responses
-	handler, err := NewRelayerExternalHandler(logger, prometheus.DefaultRegisterer)
+	handler, err := NewRelayerExternalHandler(logger, metrics, prometheus.DefaultRegisterer)
 	if err != nil {
 		logger.Error(
 			"Failed to create p2p network handler",

--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -61,7 +61,7 @@ func NewNetwork(
 	}
 
 	// Create the handler for handling inbound app responses
-	handler, err := NewRelayerExternalHandler(logger, metrics, prometheus.DefaultRegisterer)
+	handler, err := NewRelayerExternalHandler(logger, metrics)
 	if err != nil {
 		logger.Error(
 			"Failed to create p2p network handler",

--- a/peers/app_request_network_metrics.go
+++ b/peers/app_request_network_metrics.go
@@ -13,6 +13,8 @@ var (
 type AppRequestNetworkMetrics struct {
 	infoAPICallLatencyMS   prometheus.Histogram
 	pChainAPICallLatencyMS prometheus.Histogram
+	connects               prometheus.Counter
+	disconnects            prometheus.Counter
 }
 
 func newAppRequestNetworkMetrics(registerer prometheus.Registerer) (*AppRequestNetworkMetrics, error) {
@@ -40,8 +42,32 @@ func newAppRequestNetworkMetrics(registerer prometheus.Registerer) (*AppRequestN
 	}
 	registerer.MustRegister(pChainAPICallLatencyMS)
 
+	connects := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "connects",
+			Help: "Number of connected events",
+		},
+	)
+	if connects == nil {
+		return nil, ErrFailedToCreateAppRequestNetworkMetrics
+	}
+	registerer.MustRegister(connects)
+
+	disconnects := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "disconnects",
+			Help: "Number of disconnected events",
+		},
+	)
+	if disconnects == nil {
+		return nil, ErrFailedToCreateAppRequestNetworkMetrics
+	}
+	registerer.MustRegister(disconnects)
+
 	return &AppRequestNetworkMetrics{
 		infoAPICallLatencyMS:   infoAPICallLatencyMS,
 		pChainAPICallLatencyMS: pChainAPICallLatencyMS,
+		connects:               connects,
+		disconnects:            disconnects,
 	}, nil
 }

--- a/peers/external_handler.go
+++ b/peers/external_handler.go
@@ -43,7 +43,6 @@ type expectedResponses struct {
 func NewRelayerExternalHandler(
 	logger logging.Logger,
 	metrics *AppRequestNetworkMetrics,
-	registerer prometheus.Registerer,
 ) (*RelayerExternalHandler, error) {
 	// TODO: Leaving this static for now, but we may want to have this as a config option
 	cfg := timer.AdaptiveTimeoutConfig{
@@ -54,7 +53,7 @@ func NewRelayerExternalHandler(
 		TimeoutHalflife:    constants.DefaultNetworkTimeoutHalflife,
 	}
 
-	timeoutManager, err := timer.NewAdaptiveTimeoutManager(&cfg, registerer)
+	timeoutManager, err := timer.NewAdaptiveTimeoutManager(&cfg, prometheus.DefaultRegisterer)
 	if err != nil {
 		logger.Error(
 			"Failed to create timeout manager",


### PR DESCRIPTION
## Why this should be merged

Instead of moving Connected/Disconnected log events back to info level this collects metrics on the number of connect and disconnect events that occur. As of now, the applications don't initiate any disconnects so alerts can be created to monitor for excessive disconnects initiated by network peers. 

Also fixed the typo in the `app_request_network_metrics.go` filename

## How this works

I re-used recently added `AppRequestNetworkMetrics` struct since these are fundamentally still related to the `AppRequestNetwork`.