### PR TITLE
nit: move isEmptyOrZeroes to utils and added unittest for it

### DIFF
--- a/signature-aggregator/api/api.go
+++ b/signature-aggregator/api/api.go
@@ -78,15 +78,6 @@ func writeJSONError(
 	}
 }
 
-func isEmptyOrZeroes(bytes []byte) bool {
-	for _, b := range bytes {
-		if b != 0 {
-			return false
-		}
-	}
-	return true
-}
-
 func signatureAggregationAPIHandler(
 	logger logging.Logger,
 	metrics *metrics.SignatureAggregatorMetrics,
@@ -140,7 +131,7 @@ func signatureAggregationAPIHandler(
 			return
 		}
 
-		if isEmptyOrZeroes(message.Bytes()) && isEmptyOrZeroes(justification) {
+		if utils.IsEmptyOrZeroes(message.Bytes()) && utils.IsEmptyOrZeroes(justification) {
 			writeJSONError(
 				logger,
 				w,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -146,3 +146,13 @@ func HexOrCB58ToID(s string) (ids.ID, error) {
 	}
 	return ids.FromString(s)
 }
+
+// IsEmptyOrZeroes returns true if the byte slice is empty or all zeroes
+func IsEmptyOrZeroes(bytes []byte) bool {
+	for _, b := range bytes {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -135,3 +135,41 @@ func TestCheckStakeWeightExceedsThreshold(t *testing.T) {
 		})
 	}
 }
+
+func TestIsEmptyOrZeroes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected bool
+	}{
+		{
+			name:     "empty slice",
+			input:    []byte{},
+			expected: true,
+		},
+		{
+			name:     "all zeroes",
+			input:    []byte{0, 0, 0},
+			expected: true,
+		},
+		{
+			name:     "contains non-zero value",
+			input:    []byte{0, 1, 0},
+			expected: false,
+		},
+		{
+			name:     "all non-zero values",
+			input:    []byte{1, 2, 3},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsEmptyOrZeroes(tt.input)
+			if result != tt.expected {
+				t.Errorf("isEmptyOrZeroes(%v) = %v; want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why this should be merged  

it moves supporting func isEmptyOrZeroes into utils and exposes it to be used in avalanche-cli
also adds unittest for it

## How this works
drop in replacement 

## How this was tested
using unittest 

## How is this documented
n/a