### PR TITLE
Remove submodules from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,10 +17,6 @@ updates:
       - dependency-name: "github.com/ethereum/go-ethereum"
       # Avalanchego is updated to stay compatible with subnet-evm
       - dependency-name: "github.com/ava-labs/avalanchego"
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Why this should be merged
Removes submodules from dependabot PRs reducing email spam :)