### PR TITLE
Fixup release flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $ docker run -v $(pwd)/signature-aggregator/sample-signature-aggregator-config.j
 Or, for the relayer:
 
 ```bash
-$ goreleaser release --single-target --clean --snapshot --config signature-aggregator/.goreleaser.yml
+$ goreleaser release --single-target --clean --snapshot --config relayer/.goreleaser.yml
 ...
-$ docker run -v $(pwd)/signature-aggregator/sample-signature-aggregator-config.json:/config.json avaplatform/signature-aggregator:v0.1.0-rc0-amd64 --config-file /config.json
+$ docker run -v $(pwd)/sample-relayer-config.json:/config.json avaplatform/awm-relayer:v1.0.4-test12-amd64 --config-file /config.json
 ```

--- a/README.md
+++ b/README.md
@@ -41,3 +41,16 @@ Running the tests locally doesn't require publishing the `subnet-evm` commit sin
 
 > [!TIP]
 > Using the local checkout it's possible to run tests against a `tmpnet` consisting of nodes using a different version of `avalanchego` than the application being tested which might be helpful when troubleshooting.
+
+## Releases
+GoReleaser is used to build the binaries of the services and also Docker images with those binaries. The monorepo feature of GoReleaser Pro is used to automate the release flow in response to tags like `signature-aggregator/v0.0.0`. The release actions in .github/workflows automate this, but the release build can also be run locally. Be sure to install the "pro" distribution of the command line utility, so that it can parse the `monorepo` key. For example:
+
+```bash
+$ goreleaser release --single-target --clean --snapshot --config signature-aggregator/.goreleaser.yml
+...
+    • creating                                       archive=dist/linux_amd64/signature-aggregator_0.1.0-rc0-SNAPSHOT-3c2ae78_linux_amd64.tar.gz
+  • docker images
+    • building docker image                          image=avaplatform/signature-aggregator:v0.1.0-rc0-amd64
+...
+$ docker run avaplatform/signature-aggregator:v0.1.0-rc0-amd64
+```

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ $ goreleaser release --single-target --clean --snapshot --config signature-aggre
     • creating                                       archive=dist/linux_amd64/signature-aggregator_0.1.0-rc0-SNAPSHOT-3c2ae78_linux_amd64.tar.gz
   • docker images
     • building docker image                          image=avaplatform/signature-aggregator:v0.1.0-rc0-amd64
-...
-$ docker run avaplatform/signature-aggregator:v0.1.0-rc0-amd64
+```
+
+Then:
+
+```bash
+$ docker run -v $(pwd)/signature-aggregator/sample-signature-aggregator-config.json:/config.json avaplatform/signature-aggregator:v0.1.0-rc0-amd64 --config-file /config.json
+{"level":"info","timestamp":"2024-09-11T22:25:03.001Z","logger":"signature-aggregator","caller":"main/main.go:76","msg":"Initializing signature-aggregator"}
+{"level":"info","timestamp":"2024-09-11T22:25:03.001Z","logger":"signature-aggregator","caller":"main/main.go:79","msg":"Initializing app request network"}
+{"level":"debug","timestamp":"2024-09-11T22:25:03.086Z","logger":"p2p-network","caller":"dialer/dialer.go:52","msg":"creating dialer","throttleRPS":50,"dialTimeout":30000000000}
+{"level":"info","timestamp":"2024-09-11T22:25:03.086Z","logger":"signature-aggregator","caller":"main/main.go:134","msg":"Initialization complete"}
 ```

--- a/README.md
+++ b/README.md
@@ -62,3 +62,11 @@ $ docker run -v $(pwd)/signature-aggregator/sample-signature-aggregator-config.j
 {"level":"debug","timestamp":"2024-09-11T22:25:03.086Z","logger":"p2p-network","caller":"dialer/dialer.go:52","msg":"creating dialer","throttleRPS":50,"dialTimeout":30000000000}
 {"level":"info","timestamp":"2024-09-11T22:25:03.086Z","logger":"signature-aggregator","caller":"main/main.go:134","msg":"Initialization complete"}
 ```
+
+Or, for the relayer:
+
+```bash
+$ goreleaser release --single-target --clean --snapshot --config signature-aggregator/.goreleaser.yml
+...
+$ docker run -v $(pwd)/signature-aggregator/sample-signature-aggregator-config.json:/config.json avaplatform/signature-aggregator:v0.1.0-rc0-amd64 --config-file /config.json
+```

--- a/relayer/Dockerfile
+++ b/relayer/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11-slim
+FROM debian:12-slim
 RUN apt update && apt --yes install ca-certificates
 COPY awm-relayer /usr/bin/awm-relayer
 EXPOSE 8080

--- a/relayer/Dockerfile
+++ b/relayer/Dockerfile
@@ -1,4 +1,5 @@
 FROM debian:11-slim
+RUN apt update && apt --yes install ca-certificates
 COPY awm-relayer /usr/bin/awm-relayer
 EXPOSE 8080
 USER 1001

--- a/signature-aggregator/Dockerfile
+++ b/signature-aggregator/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11-slim
+FROM debian:12-slim
 COPY signature-aggregator /usr/bin/signature-aggregator
 RUN apt update && apt --yes install ca-certificates
 EXPOSE 8080

--- a/signature-aggregator/Dockerfile
+++ b/signature-aggregator/Dockerfile
@@ -1,5 +1,6 @@
 FROM debian:11-slim
 COPY signature-aggregator /usr/bin/signature-aggregator
+RUN apt update && apt --yes install ca-certificates
 EXPOSE 8080
 EXPOSE 8081
 CMD ["start"]


### PR DESCRIPTION
## Why this should be merged
Issues were encountered when trying to run the docker images built by the new release flow. This fixes the problems and polishes a few other things along the way.

## How this was tested
by running the commands shown in the readme, and by pushing a `...-dev` release tag, which triggered the CI job [here](https://github.com/ava-labs/awm-relayer/actions/runs/10820990388/job/30022145358), which pushed the docker image to docker hub as `avaplatform/signature-aggregator:v0.1.0-rc1-dev` [here](https://hub.docker.com/layers/avaplatform/signature-aggregator/v0.1.0-rc1-dev/images/sha256-392651b9d5cbad9f3145488153179c5394d4983b3234dbfb0c034d01c9e06f0b?context=explore), and then by running the docker image with
```
$ docker pull avaplatform/signature-aggregator:v0.1.0-rc1-dev
...
$ docker run -v $(pwd)/signature-aggregator/sample-signature-aggregator-config.json:/config.json avaplatform/signature-aggregator:v0.1.0-rc1-dev --config-file /config.json
```

## How is this documented
in the README changes