### PR TITLE
Add error HTTP status codes and fix error json marshal

### DIFF
--- a/signature-aggregator/README.md
+++ b/signature-aggregator/README.md
@@ -41,7 +41,13 @@ The successful `HTTP 200` response format is
 }
 ```
 
-Unsuccessful responses will include an explanatory `application/json` encoded message in the body of the response.
+Unsuccessful responses will include an explanatory `application/json` encoded `error` message in the body of the response along with an appropriate `4xx` or `5xx` status code for user input errors or server side errors respectively e.g.:
+
+```json
+{
+    "error": "Could not decode message"
+}
+```
 
 ## Sample workflow
 If you want to manually test a locally running service pointed to the Fuji testnet you can do so with the following steps.

--- a/signature-aggregator/api/api.go
+++ b/signature-aggregator/api/api.go
@@ -43,6 +43,10 @@ type AggregateSignatureResponse struct {
 	SignedMessage string `json:"signed-message"`
 }
 
+type AggregateSignatureErrorResponse struct {
+	Error string `json:"error"`
+}
+
 func HandleAggregateSignaturesByRawMsgRequest(
 	logger logging.Logger,
 	metrics *metrics.SignatureAggregatorMetrics,
@@ -61,9 +65,14 @@ func HandleAggregateSignaturesByRawMsgRequest(
 func writeJSONError(
 	logger logging.Logger,
 	w http.ResponseWriter,
+	httpStatusCode int,
 	errorMsg string,
 ) {
-	resp, err := json.Marshal(struct{ error string }{error: errorMsg})
+	resp, err := json.Marshal(
+		AggregateSignatureErrorResponse{
+			Error: errorMsg,
+		},
+	)
 	if err != nil {
 		msg := "Error marshalling JSON error response"
 		logger.Error(msg, zap.Error(err))
@@ -71,8 +80,9 @@ func writeJSONError(
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(httpStatusCode)
 
-	w.Write(resp)
+	_, err = w.Write(resp)
 	if err != nil {
 		logger.Error("Error writing error response", zap.Error(err))
 	}
@@ -92,7 +102,7 @@ func signatureAggregationAPIHandler(
 		if err != nil {
 			msg := "Could not decode request body"
 			logger.Warn(msg, zap.Error(err))
-			writeJSONError(logger, w, msg)
+			writeJSONError(logger, w, http.StatusBadRequest, msg)
 			return
 		}
 		var decodedMessage []byte
@@ -106,14 +116,14 @@ func signatureAggregationAPIHandler(
 				zap.String("msg", req.Message),
 				zap.Error(err),
 			)
-			writeJSONError(logger, w, msg)
+			writeJSONError(logger, w, http.StatusBadRequest, msg)
 			return
 		}
 		message, err := types.UnpackWarpMessage(decodedMessage)
 		if err != nil {
 			msg := "Error unpacking warp message"
 			logger.Warn(msg, zap.Error(err))
-			writeJSONError(logger, w, msg)
+			writeJSONError(logger, w, http.StatusBadRequest, msg)
 			return
 		}
 
@@ -127,7 +137,7 @@ func signatureAggregationAPIHandler(
 				zap.String("justification", req.Justification),
 				zap.Error(err),
 			)
-			writeJSONError(logger, w, msg)
+			writeJSONError(logger, w, http.StatusBadRequest, msg)
 			return
 		}
 
@@ -135,6 +145,7 @@ func signatureAggregationAPIHandler(
 			writeJSONError(
 				logger,
 				w,
+				http.StatusBadRequest,
 				"Must provide either message or justification",
 			)
 			return
@@ -146,7 +157,7 @@ func signatureAggregationAPIHandler(
 		} else if req.QuorumPercentage > 100 {
 			msg := "Invalid quorum number"
 			logger.Warn(msg, zap.Uint64("quorum-num", req.QuorumPercentage))
-			writeJSONError(logger, w, msg)
+			writeJSONError(logger, w, http.StatusBadRequest, msg)
 			return
 		}
 		var signingSubnetID ids.ID
@@ -161,7 +172,7 @@ func signatureAggregationAPIHandler(
 					zap.Error(err),
 					zap.String("input", req.SigningSubnetID),
 				)
-				writeJSONError(logger, w, msg)
+				writeJSONError(logger, w, http.StatusBadRequest, msg)
 				return
 			}
 		}
@@ -175,7 +186,7 @@ func signatureAggregationAPIHandler(
 		if err != nil {
 			msg := "Failed to aggregate signatures"
 			logger.Warn(msg, zap.Error(err))
-			writeJSONError(logger, w, msg)
+			writeJSONError(logger, w, http.StatusInternalServerError, msg)
 			return
 		}
 		resp, err := json.Marshal(
@@ -189,7 +200,7 @@ func signatureAggregationAPIHandler(
 		if err != nil {
 			msg := "Failed to marshal response"
 			logger.Error(msg, zap.Error(err))
-			writeJSONError(logger, w, msg)
+			writeJSONError(logger, w, http.StatusInternalServerError, msg)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Why this should be merged


## How this works
`writeJsonError` didn't actually correctly serialize errors since the anonymous struct it was marshalling didn't have exposed fields so it would marshall to an empty struct.

Added status code to distinguish to the caller between user input errors and server side errors. Requests resulting in 5xx level errors can be retried and may succeed in the future while 4xx errors represent malformed or invalid input.

## How this was tested
compiled the binary and manually tested against Fuji with common user supplied error cases. Got valid error reponses like:
```
➜  Code ./sendBadTx.sh
HTTP/1.1 400 Bad Request
Content-Type: application/json
Date: Fri, 20 Sep 2024 14:16:14 GMT
Content-Length: 36

{"error":"Could not decode message"}%
```

## How is this documented
Updated the docs