### PR TITLE
Add code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,26 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Run Relayer Unit Tests
-        run: ./scripts/test.sh
+        run: ./scripts/test.sh --cover
+
+      - name: Upload code coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage
+          path: coverage.txt
+
+  code_coverage:
+    name: "Code coverage Report"
+    if: github.event_name == 'pull_request' # Do not run when workflow is triggered by push to main branch
+    runs-on: ubuntu-latest
+    needs: test_relayer # Depends on the artifact uploaded by the test_relayer job
+    permissions:
+      contents:      read
+      actions:       read
+      pull-requests: write
+    steps:
+      - uses: fgrosse/go-coverage-report@v1.1.1
+        with:
+          coverage-artifact-name: "code-coverage"
+          coverage-file-name: "coverage.txt"
+    

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       actions:       read
       pull-requests: write
     steps:
-      - uses: fgrosse/go-coverage-report@v1.1.1
+      - uses: fgrosse/go-coverage-report@v1.2.0
         with:
           coverage-artifact-name: "code-coverage"
           coverage-file-name: "coverage.txt"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
   code_coverage:
     name: "Code coverage Report"
     if: github.event_name == 'pull_request' # Do not run when workflow is triggered by push to main branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: test_relayer # Depends on the artifact uploaded by the test_relayer job
     permissions:
       contents:      read

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,10 +8,12 @@ set -o pipefail
 
 VERBOSE=
 HELP=
+COVER=
 while [ $# -gt 0 ]; do
     case "$1" in
         -v | --verbose) VERBOSE=-test.v ;;
         -h | --help) HELP=true ;;
+        -c | --cover) COVER="-cover -coverprofile=coverage.txt ";;
     esac
     shift
 done
@@ -23,6 +25,7 @@ if [ "$HELP" = true ]; then
     echo "Options:"
     echo "  -v, --verbose                     Run the test with verbose output"
     echo "  -h, --help                        Print this help message"
+    echo "  -c  --cover                       Generate code coverage report"
     exit 0
 fi
 
@@ -37,4 +40,4 @@ go build -o tests/cmd/decider/decider ./tests/cmd/decider/
 
 "$root"/scripts/generate.sh
 
-go test -tags testing $VERBOSE ./...
+go test -tags testing $VERBOSE $COVER ./...


### PR DESCRIPTION
## Why this should be merged
Adds code-coverage to the PRs
## How this works

- Adds a flag to output `codecoverage.txt` to the `scripts/test.sh
- Adds a step to upload the output as an artifact to GH
- Adds an action to post it to the PR

## How this was tested

## How is this documented