### PR TITLE
Create default registry at runtime

### DIFF
--- a/peers/external_handler.go
+++ b/peers/external_handler.go
@@ -53,7 +53,7 @@ func NewRelayerExternalHandler(
 		TimeoutHalflife:    constants.DefaultNetworkTimeoutHalflife,
 	}
 
-	timeoutManager, err := timer.NewAdaptiveTimeoutManager(&cfg, prometheus.DefaultRegisterer)
+	timeoutManager, err := timer.NewAdaptiveTimeoutManager(&cfg, prometheus.NewRegistry())
 	if err != nil {
 		logger.Error(
 			"Failed to create timeout manager",


### PR DESCRIPTION
## Why this should be merged
We currently use `prometheus.DefaultRegisterer` as the registerer for metrics we don't intend to collect. `DefaultRegisterer` simply calls `NewRegistry()` at compile time. In situations that create `NewSignatureAggregator`s within the same application instance (such as Ginkgo test suites), this can cause the aggregator to fail with `AlreadyRegisteredError`.

## How this works
Replaces `DefaultRegisterer` with `NewRegistry()` so that the no-op registry is created at runtime rather than compile time.

## How this was tested
CI

## How is this documented
N/A