### PR TITLE
Add extra peer endpoints to aggregator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/ava-labs/awm-relayer
 
-go 1.22.7
+go 1.22.8
 
 require (
-	github.com/ava-labs/avalanchego v1.11.11
+	github.com/ava-labs/avalanchego v1.12.0-initial-poc.0
 	github.com/ava-labs/coreth v0.13.8
 	github.com/ava-labs/subnet-evm v0.6.10
 	github.com/ava-labs/teleporter v1.0.7
@@ -85,7 +85,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/rpc v1.2.0 // indirect
-	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/alexliesenfeld/health v0.8.0/go.mod h1:TfNP0f+9WQVWMQRzvMUjlws4ceXKEL
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.11.11 h1:MIQq8xRavRj4ZXHA4G+aMiymig7SOScGOG1SApmMvBc=
-github.com/ava-labs/avalanchego v1.11.11/go.mod h1:yFx3V31Jy9NFa8GZlgGnwiVf8KGjeF2+Uc99l9Scd/8=
+github.com/ava-labs/avalanchego v1.12.0-initial-poc.0 h1:9JO0Yh4+fWfuoNenPgkJsaVuIh8cq4c1rYTD8Hv9fU8=
+github.com/ava-labs/avalanchego v1.12.0-initial-poc.0/go.mod h1:qSHmog3wMVjo/ruIAQo0ppXAilyni07NIu5K88RyhWE=
 github.com/ava-labs/coreth v0.13.8 h1:f14X3KgwHl9LwzfxlN6S4bbn5VA2rhEsNnHaRLSTo/8=
 github.com/ava-labs/coreth v0.13.8/go.mod h1:t3BSv/eQv0AlDPMfEDCMMoD/jq1RkUsbFzQAFg5qBcE=
 github.com/ava-labs/subnet-evm v0.6.10 h1:uIh6bFMA4GCMVMQ3agBPxTMlYHL8FBR5FrhMR+drfKI=
@@ -355,8 +355,8 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/rpc v1.2.0 h1:WvvdC2lNeT1SP32zrIce5l0ECBfbAlmrmSBsuc57wfk=
 github.com/gorilla/rpc v1.2.0/go.mod h1:V4h9r+4sF5HnzqbwIez0fKSpANP0zlYd3qR7p36jkTQ=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
-github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0 h1:RtRsiaGvWxcwd8y3BiRZxsylPT8hLWZ5SPcfI+3IDNk=

--- a/peers/external_handler.go
+++ b/peers/external_handler.go
@@ -53,7 +53,7 @@ func NewRelayerExternalHandler(
 		TimeoutHalflife:    constants.DefaultNetworkTimeoutHalflife,
 	}
 
-	timeoutManager, err := timer.NewAdaptiveTimeoutManager(&cfg, prometheus.DefaultRegisterer)
+	timeoutManager, err := timer.NewAdaptiveTimeoutManager(&cfg, prometheus.NewRegistry())
 	if err != nil {
 		logger.Error(
 			"Failed to create timeout manager",

--- a/peers/info_client.go
+++ b/peers/info_client.go
@@ -72,6 +72,6 @@ func (i *InfoAPI) Peers(ctx context.Context) ([]info.Peer, error) {
 	return i.client.Peers(ctx, i.options...)
 }
 
-func (i *InfoAPI) Uptime(ctx context.Context, subnetID ids.ID) (*info.UptimeResponse, error) {
-	return i.client.Uptime(ctx, subnetID, i.options...)
+func (i *InfoAPI) Uptime(ctx context.Context) (*info.UptimeResponse, error) {
+	return i.client.Uptime(ctx, i.options...)
 }

--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -153,6 +153,7 @@ func main() {
 		networkLogLevel,
 		registerer,
 		trackedSubnets,
+		nil,
 		&cfg,
 	)
 	if err != nil {

--- a/signature-aggregator/main/main.go
+++ b/signature-aggregator/main/main.go
@@ -88,6 +88,7 @@ func main() {
 		networkLogLevel,
 		prometheus.DefaultRegisterer,
 		nil,
+		nil,
 		&cfg,
 	)
 	if err != nil {


### PR DESCRIPTION
## Why this should be merged
Certain devnet endpoints does not correctly return all external nodes connected to the devnet validators. 
As is currently the case with etna. The PR enables passing to the aggregator nodes that are not included
in canonical info.peers from the devnet endpoint.

## How this works
It enables passing to the aggregator a list of endpoints from which to generate extra peers.

## How this was tested
CLI branch that connects a local node to etna and needs the aggregator to include it in the aggregation 

## How is this documented