### PR TITLE
use warpRequirePrimaryNetworkSigners config

### DIFF
--- a/relayer/config/config_test.go
+++ b/relayer/config/config_test.go
@@ -258,17 +258,6 @@ func TestGetWarpQuorum(t *testing.T) {
 		expectedQuorum      WarpQuorum
 	}{
 		{
-			name:                "primary network",
-			blockchainID:        blockchainID,
-			subnetID:            ids.Empty,
-			getChainConfigCalls: 0,
-			expectedError:       nil,
-			expectedQuorum: WarpQuorum{
-				QuorumNumerator:   warp.WarpDefaultQuorumNumerator,
-				QuorumDenominator: warp.WarpQuorumDenominator,
-			},
-		},
-		{
 			name:                "subnet genesis precompile",
 			blockchainID:        blockchainID,
 			subnetID:            subnetID,
@@ -364,8 +353,9 @@ func TestGetWarpQuorum(t *testing.T) {
 				).Times(testCase.getChainConfigCalls),
 			)
 
-			quorum, err := getWarpQuorum(testCase.subnetID, testCase.blockchainID, client)
+			warpConfig, err := getWarpConfig(client)
 			require.Equal(t, testCase.expectedError, err)
+			quorum := calculateQuorum(warpConfig.QuorumNumerator)
 			require.Equal(t, testCase.expectedQuorum, quorum)
 		})
 	}

--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -80,7 +80,7 @@ func main() {
 	}
 	// Initialize the Warp Quorum values by fetching via RPC
 	// We do this here so that BuildConfig doesn't need to make RPC calls
-	if err = cfg.InitializeWarpQuorums(); err != nil {
+	if err = cfg.InitializeWarpConfigs(); err != nil {
 		panic(fmt.Errorf("couldn't initialize warp quorums: %w", err))
 	}
 


### PR DESCRIPTION
## Why this should be merged
Fixes #454 
## How this works
Fetches the additional value from the config and uses it when creating application relayer struct.  

Open q: `WarpQuorum` struct doesn't seem very useful since denominator is hardcoded at compile time to 100 
## How this was tested
Existing tests should pass
TODO: add new ones

## How is this documented