### PR TITLE
Fix signature-aggregator arm builds

### DIFF
--- a/.github/workflows/release_awm_relayer.yml
+++ b/.github/workflows/release_awm_relayer.yml
@@ -61,7 +61,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: latest
+          version: '~> v2'
           args: release --clean --config relayer/.goreleaser.yml
         env:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret

--- a/.github/workflows/release_signature_aggregator.yml
+++ b/.github/workflows/release_signature_aggregator.yml
@@ -61,7 +61,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: latest
+          version: '~> v2'
           args: release --clean --config signature-aggregator/.goreleaser.yml
         env:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret

--- a/relayer/.goreleaser.yml
+++ b/relayer/.goreleaser.yml
@@ -1,5 +1,6 @@
 # ref. https://goreleaser.com/customization/build/
 project_name: awm-relayer
+version: 2
 monorepo:
   tag_prefix: awm-relayer/
 builds:

--- a/signature-aggregator/.goreleaser.yml
+++ b/signature-aggregator/.goreleaser.yml
@@ -1,5 +1,6 @@
 # ref. https://goreleaser.com/customization/build/
 project_name: signature-aggregator
+version: 2
 monorepo:
   tag_prefix: signature-aggregator/
 builds:

--- a/signature-aggregator/.goreleaser.yml
+++ b/signature-aggregator/.goreleaser.yml
@@ -22,10 +22,12 @@ builds:
     overrides:
       - goos: linux
         goarch: arm64
+        goarm64: v8.0
         env:
           - CC=aarch64-linux-gnu-gcc
       - goos: darwin
         goarch: arm64
+        goarm64: v8.0
         env:
           - CC=oa64-clang
     ignore:


### PR DESCRIPTION
## Why this should be merged
I failed to realize that https://github.com/ava-labs/awm-relayer/pull/565 only fixed the ARM builds for awm-relayer. This fixes the signature-aggregator builds as well

## How this works

## How this was tested

## How is this documented